### PR TITLE
fix(tests): make unit tests build on Windows

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -135,6 +135,69 @@ jobs:
       - name: ccache stats
         run: ccache -s | head -8
 
+  cpp-tests-windows:
+    # The ONLY lane that compiles tests/ on Windows. Before it existed nothing
+    # did: cpp-tests above runs Linux + macOS-arm64, and every Windows lane in
+    # the repo (cuda-windows, python-wheels) builds through SKBUILD, which
+    # forces TRANSCRIBE_BUILD_TESTS=OFF. So the Windows-portability shims in
+    # tests/ (_getpid, _putenv_s, std::filesystem temp files in place of
+    # mkstemps) were unguarded and could rot silently between releases.
+    #
+    # Two postures, because they exercise DIFFERENT toolchains:
+    #   windows-x64   -> the default MSVC toolset (cl.exe)
+    #   windows-arm64 -> ClangCL, NOT MSVC. ggml's CPU backend hard-fails on
+    #                    ARM under MSVC ("MSVC is not supported for ARM, use
+    #                    clang", ggml/src/ggml-cpu/CMakeLists.txt), so the
+    #                    ARM64 posture is only buildable with clang-cl. The
+    #                    windows-11-arm image ships the VC.Llvm.Clang +
+    #                    VC.Llvm.ClangToolset components that needs.
+    #
+    # GGML_NATIVE=OFF on ARM64 only: ggml's native-ARM probe shells out with
+    # INPUT_FILE "/dev/null" (not a path on Windows) and detects
+    # dotprod/i8mm/SVE/SME via check_cxx_source_runs. Off pins a deterministic
+    # armv8-a baseline instead of depending on the runner SKU. x64 keeps the
+    # dev posture (NATIVE on) to match cpp-tests.
+    #
+    # Scope is configure + build + ctest. The install/link-smoke step from
+    # cpp-tests is deliberately absent: scripts/ci/link_smoke.py drives a POSIX
+    # cc driver (-I/-l/-L/-Wl,-rpath/-framework), none of which cl.exe or
+    # clang-cl's CL-compatible driver accept. Porting it is separate work.
+    #
+    # transcribe_loader_smoke does not register here (no uv on PATH). uv is
+    # only Tier 2 on Windows ARM64 and its `python install` still resolves an
+    # x86_64 CPython there, so it is left out rather than made conditional.
+    #
+    # NOTE: runs-on windows-11-arm is free for PUBLIC repos only — the label
+    # fails to resolve on a private repo. Revisit if this repo ever goes private.
+    name: cpp-tests (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: windows-x64
+            runner: windows-latest
+            arch: x64
+            extra: ""
+          - label: windows-arm64
+            runner: windows-11-arm
+            arch: ARM64
+            extra: "-T ClangCL -DGGML_NATIVE=OFF"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 40
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v6
+      # The Visual Studio generator is used rather than Ninja on purpose: it
+      # locates the toolchain itself, so no vcvars/dev-shell action is needed.
+      - name: Configure (static white-box build)
+        run: cmake -B build -G "Visual Studio 17 2022" -A ${{ matrix.arch }} ${{ matrix.extra }}
+      - name: Build
+        run: cmake --build build --config Release --parallel
+      - name: Test (full white-box suite)
+        run: ctest --test-dir build -C Release --output-on-failure
+
   cpp-tests-sanitized:
     # ASan+UBSan over the white-box suite. This is the lane that certifies
     # the C lifetime/ABI contracts the FFI bindings rely on — including the

--- a/tests/debug_dump_unit.cpp
+++ b/tests/debug_dump_unit.cpp
@@ -30,7 +30,11 @@
 #include "ggml.h"
 #include "transcribe-debug.h"
 
-#include <unistd.h>  // ::getpid()
+#ifdef _WIN32
+#    include <process.h>  // ::_getpid()
+#else
+#    include <unistd.h>   // ::getpid()
+#endif
 
 #include <cstdio>
 #include <cstdlib>
@@ -70,7 +74,11 @@ int g_failures = 0;
 // scoped to this test process. Caller deletes it on success.
 fs::path make_unique_dump_dir() {
     fs::path base = fs::temp_directory_path() / "transcribe-debug-dump-test";
+#ifdef _WIN32
+    base /= std::to_string(::_getpid());
+#else
     base /= std::to_string(::getpid());
+#endif
     fs::remove_all(base);  // ensure clean state in case of leftover
     fs::create_directories(base);
     return base;
@@ -106,6 +114,16 @@ bool contains(const std::string & haystack, const std::string & needle) {
     return haystack.find(needle) != std::string::npos;
 }
 
+// Portable setenv(name, value, 1). fs::path::c_str() is wchar_t* on
+// Windows, so callers pass a narrow std::string instead.
+bool set_env(const char * name, const std::string & value) {
+#ifdef _WIN32
+    return ::_putenv_s(name, value.c_str()) == 0;
+#else
+    return ::setenv(name, value.c_str(), 1) == 0;
+#endif
+}
+
 }  // namespace
 
 int main() {
@@ -114,8 +132,9 @@ int main() {
     // Create a unique dump dir, point TRANSCRIBE_DUMP_DIR at it, and
     // initialize the dumper. setenv before init is the contract:
     // init() reads the env var once and caches it.
-    const fs::path dump_dir = make_unique_dump_dir();
-    if (::setenv("TRANSCRIBE_DUMP_DIR", dump_dir.c_str(), 1) != 0) {
+    const fs::path    dump_dir     = make_unique_dump_dir();
+    const std::string dump_dir_str = dump_dir.string();
+    if (!set_env("TRANSCRIBE_DUMP_DIR", dump_dir_str)) {
         std::fprintf(stderr, "FAIL: setenv failed\n");
         return EXIT_FAILURE;
     }
@@ -127,9 +146,10 @@ int main() {
         return EXIT_FAILURE;
     }
     CHECK(transcribe::debug::enabled());
-    if (transcribe::debug::dump_dir() == nullptr || std::strcmp(transcribe::debug::dump_dir(), dump_dir.c_str()) != 0) {
+    if (transcribe::debug::dump_dir() == nullptr ||
+        std::strcmp(transcribe::debug::dump_dir(), dump_dir_str.c_str()) != 0) {
         std::fprintf(stderr, "FAIL: dump_dir() = \"%s\", expected \"%s\"\n",
-                     transcribe::debug::dump_dir() ? transcribe::debug::dump_dir() : "(null)", dump_dir.c_str());
+                     transcribe::debug::dump_dir() ? transcribe::debug::dump_dir() : "(null)", dump_dir_str.c_str());
         ++g_failures;
     }
 

--- a/tests/whisper_bin_parser_unit.cpp
+++ b/tests/whisper_bin_parser_unit.cpp
@@ -36,13 +36,17 @@
 #include "transcribe-bin-loader.h"
 
 #include <sys/stat.h>
-#include <unistd.h>
+#ifndef _WIN32
+#    include <unistd.h>
+#endif
 
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -186,29 +190,45 @@ bool write_synthetic_bin(const std::string & path,
     return static_cast<bool>(f);
 }
 
+// Portable stand-in for mkstemps(): create a unique empty file named
+// transcribe_bin_test_<rand>.bin in the system temp dir. Returns the
+// path, or an empty string on failure. Collision-then-overwrite is
+// acceptable for these synthetic-fixture tests.
+std::string make_temp_bin_path() {
+    std::error_code             ec;
+    const std::filesystem::path dir = std::filesystem::temp_directory_path(ec);
+    if (ec) {
+        return {};
+    }
+    std::random_device          rd;
+    const std::filesystem::path p = dir / ("transcribe_bin_test_" + std::to_string(rd()) + ".bin");
+    std::ofstream               f(p, std::ios::binary);
+    if (!f) {
+        return {};
+    }
+    return p.string();
+}
+
 void test_bad_n_fft() {
-    char      tmpl[] = "/tmp/transcribe_bin_test_XXXXXX.bin";
-    const int fd     = ::mkstemps(tmpl, 4);
-    if (fd < 0) {
+    const std::string path = make_temp_bin_path();
+    if (path.empty()) {
         std::fprintf(stderr, "SKIP: could not create tempfile for synthetic bin\n");
         ++g_skipped;
         return;
     }
-    ::close(fd);
-    const std::string path = tmpl;
 
     // Whisper-shaped hparams but non-canonical n_fft (200 instead of
     // 201). Parser must reject before we even get to the vocab phase.
     if (!write_synthetic_bin(path, 51865, 4, 4, 80, 80, 200)) {
         std::fprintf(stderr, "SKIP: failed to write synthetic .bin\n");
         ++g_skipped;
-        ::unlink(path.c_str());
+        std::remove(path.c_str());
         return;
     }
     transcribe::bin_loader::WhisperBinModel m;
     const auto                              rc = transcribe::bin_loader::parse_whisper_bin(path.c_str(), m);
     CHECK(rc == TRANSCRIBE_ERR_GGUF);
-    ::unlink(path.c_str());
+    std::remove(path.c_str());
 }
 
 void test_distil_layer_count_accepted() {
@@ -216,18 +236,15 @@ void test_distil_layer_count_accepted() {
     // whisper-shaped hparams should pass the hparams gate. We don't
     // care that the parser later fails at "no tensors" — the hparams
     // check should not be the gating step.
-    char      tmpl[] = "/tmp/transcribe_bin_test_XXXXXX.bin";
-    const int fd     = ::mkstemps(tmpl, 4);
-    if (fd < 0) {
+    const std::string path = make_temp_bin_path();
+    if (path.empty()) {
         ++g_skipped;
         return;
     }
-    ::close(fd);
-    const std::string path = tmpl;
 
     if (!write_synthetic_bin(path, 51865, 24, 2, 80, 80, 201)) {
         ++g_skipped;
-        ::unlink(path.c_str());
+        std::remove(path.c_str());
         return;
     }
     transcribe::bin_loader::WhisperBinModel m;
@@ -237,7 +254,7 @@ void test_distil_layer_count_accepted() {
     // "no tensors" / truncated diagnostic), NOT UNSUPPORTED_ARCH —
     // that's the proof that the geometry gate accepts distil layers.
     CHECK(rc == TRANSCRIBE_ERR_GGUF);
-    ::unlink(path.c_str());
+    std::remove(path.c_str());
 }
 
 }  // namespace


### PR DESCRIPTION
# Summary

This PR fixes several Windows compatibility issues in the unit tests that prevented the project from building with llvm-mingw on Windows ARM64.

The production targets (`transcribe` and `transcribe-cli`) already built successfully, but the test suite used a few POSIX-specific APIs that are unavailable on Windows.

## Changes

- Replace the POSIX-only `mkstemps` usage with a cross-platform implementation.
- Replace `setenv` with the appropriate Windows implementation where necessary.
- Fix `std::filesystem::path` handling so Windows wide-character paths are passed correctly.

## Verification

Built successfully on:

- Windows 11 ARM64 (Snapdragon X2 Plus)
- llvm-mingw 20260616 (ucrt-aarch64)
- CMake 4.4.0
- Ninja

Both the library and the complete test suite now build successfully.