### PR TITLE
parakeet: optimize long ChunkedLimited attention

### DIFF
--- a/src/arch/parakeet/encoder.cpp
+++ b/src/arch/parakeet/encoder.cpp
@@ -42,6 +42,8 @@ namespace {
 
 namespace conf = transcribe::conformer;
 
+constexpr int kWindowedChunkMinWindowCount = 12;
+
 // ----- Per-family depthwise dispatch policy -----
 //
 // In-block depthwise conv uses the direct conv_2d_dw path on every
@@ -404,26 +406,45 @@ EncoderBuild build_encoder_graph(ggml_context *                     ctx,
         // pos_emb input, ne = [d_model, pos_len, 1, 1] (numpy
         // (pos_len, d_model)), filled by the driver. Local attention
         // (Regular, both contexts >= 0) shortens pos_len to (left+right+1)
-        // (NeMo LocalAttRelPositionalEncoding); ChunkedLimited keeps the
-        // full 2T-1 and uses a separate mask. ChunkedLimitedWithRc engages
-        // the mask only when buf_mask is non-null (offline runs full attn).
+        // (NeMo LocalAttRelPositionalEncoding). Long single-utterance
+        // ChunkedLimited runs use the exact bounded query/key geometry;
+        // shorter, batched, and debug runs retain the dense reference graph.
+        // ChunkedLimitedWithRc engages its dense mask only when buf_mask is
+        // non-null (offline runs full attention).
         const bool is_chunked =
             (hp.enc_att_context_style == ParakeetHParams::AttContextStyle::ChunkedLimited) ||
             (hp.enc_att_context_style == ParakeetHParams::AttContextStyle::ChunkedLimitedWithRc && buf_mask != nullptr);
+        const int     chunk_size       = hp.enc_att_context_right + 1;
+        const int     left_chunks      = chunk_size > 0 ? hp.enc_att_context_left / chunk_size : 0;
+        const int     chunk_window     = (left_chunks + 1) * chunk_size;
+        // Window materialization has a fixed reshape/im2col cost. Keep the
+        // dense graph below the measured crossover so short requests do not
+        // regress; long requests replace quadratic attention with O(T*W).
+        const bool    windowed_chunked = hp.enc_att_context_style == ParakeetHParams::AttContextStyle::ChunkedLimited &&
+                                         n_batch == 1 && !var_len_masks && !transcribe::debug::enabled() &&
+                                         chunk_size > 0 && hp.enc_att_context_left >= 0 &&
+                                         T_enc > kWindowedChunkMinWindowCount * chunk_window;
         const bool    is_local_pe = (!is_chunked) && (hp.enc_att_context_left >= 0 && hp.enc_att_context_right >= 0);
-        const int64_t pos_len     = is_local_pe ?
-                                        static_cast<int64_t>(hp.enc_att_context_left + hp.enc_att_context_right + 1) :
-                                        (2 * T_enc - 1);
-        eb.pos_emb_in             = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, hp.enc_d_model, pos_len);
+        const int64_t pos_len =
+            windowed_chunked ? static_cast<int64_t>(chunk_window + chunk_size - 1) :
+            is_local_pe      ? static_cast<int64_t>(hp.enc_att_context_left + hp.enc_att_context_right + 1) :
+                               (2 * T_enc - 1);
+        eb.pos_emb_in = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, hp.enc_d_model, pos_len);
         ggml_set_name(eb.pos_emb_in, "pos_emb.in");
         ggml_set_input(eb.pos_emb_in);
 
-        // ChunkedLimited mask. [T_enc, T_enc, 1, 1] F32; the driver
-        // fills it host-side after the compute buffer is allocated.
-        // Broadcasts across heads inside rel_pos_mhsa.
+        // ChunkedLimited mask. The dense reference graph uses
+        // [T_enc,T_enc,1,1]. The bounded graph uses
+        // [chunk_window,chunk_size,1,n_chunks], including only prefix/tail
+        // padding masks; its chunk topology supplies the interior band.
         ggml_tensor * chunked_mask_in = nullptr;
         if (is_chunked) {
-            chunked_mask_in = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, T_enc, T_enc, 1, 1);
+            if (windowed_chunked) {
+                const int64_t n_chunks = (T_enc + chunk_size - 1) / chunk_size;
+                chunked_mask_in        = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, chunk_window, chunk_size, 1, n_chunks);
+            } else {
+                chunked_mask_in = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, T_enc, T_enc, 1, 1);
+            }
             ggml_set_name(chunked_mask_in, "attn.chunked_mask.in");
             ggml_set_input(chunked_mask_in);
             eb.chunked_mask_in = chunked_mask_in;
@@ -476,6 +497,7 @@ EncoderBuild build_encoder_graph(ggml_context *                     ctx,
         bparams.att_context_right  = hp.enc_att_context_right;
         bparams.att_context_style  = is_chunked ? conf::BlockParams::AttContextStyle::ChunkedLimited :
                                                   conf::BlockParams::AttContextStyle::Regular;
+        bparams.chunked_windowed   = windowed_chunked;
         bparams.attn_chunked_mask  = chunked_mask_in;
         bparams.attn_pad_mask      = attn_pad_mask_in;
         bparams.conv_context_left  = hp.enc_conv_context_left;

--- a/src/arch/parakeet/encoder.h
+++ b/src/arch/parakeet/encoder.h
@@ -91,17 +91,17 @@ struct EncoderBuild {
     // ne[0]=fastest convention for this 2-D tensor).
     ggml_tensor * mel_in = nullptr;
 
-    // Sinusoidal positional embedding handle, ne=[d_model, 2*T_enc-1, 1, 1].
-    // The driver computes the buffer host-side from T_enc (read from
-    // out->ne[1] after build) and uploads via ggml_backend_tensor_set.
+    // Sinusoidal positional embedding handle, normally
+    // ne=[d_model, 2*T_enc-1, 1, 1]. Bounded ChunkedLimited attention uses
+    // ne=[d_model, window+chunk-1, 1, 1]. The driver computes the buffer
+    // host-side and uploads via ggml_backend_tensor_set.
     ggml_tensor * pos_emb_in = nullptr;
 
-    // ChunkedLimited attention mask, ne=[T_enc, T_enc, 1, 1] f32. Null
-    // for every variant on the regular / local-attention path; populated
-    // only when the hparams declare att_context_style="chunked_limited"
-    // (today: nemotron-speech-streaming-en-0.6b). Driver fills with 0
-    // on allowed (q, k) pairs and -INF outside, then ggml broadcasts
-    // across heads inside rel_pos_mhsa.
+    // ChunkedLimited attention mask, normally ne=[T_enc,T_enc,1,1] f32;
+    // bounded offline attention uses ne=[window,chunk,1,n_chunks]. Null for
+    // every variant on the regular/local-attention path. The driver fills
+    // it with 0 on allowed (q,k) pairs and -INF outside, then ggml
+    // broadcasts across heads inside rel_pos_mhsa.
     ggml_tensor * chunked_mask_in = nullptr;
 
     // Buffered-streaming conv valid-frame mask, ne=[T_enc, 1, 1, 1] f32.

--- a/src/arch/parakeet/model.cpp
+++ b/src/arch/parakeet/model.cpp
@@ -63,6 +63,7 @@ ParakeetSession::~ParakeetSession() {
         sched = nullptr;
     }
     if (compute_ctx != nullptr) {
+        stream_graph.reset();
         ggml_free(compute_ctx);
         compute_ctx = nullptr;
     }
@@ -928,6 +929,7 @@ static transcribe_status run_one_shot_inner(ParakeetSession *             pc,
     // ----- Reset per-call compute state -----
     // Free the previous run's compute_ctx; encoder_out is invalidated.
     if (pc->compute_ctx != nullptr) {
+        pc->stream_graph.reset();
         ggml_free(pc->compute_ctx);
         pc->compute_ctx = nullptr;
     }
@@ -1027,12 +1029,16 @@ static transcribe_status run_one_shot_inner(ParakeetSession *             pc,
         const int d_model = pm->hparams.enc_d_model;
         const int pos_len = static_cast<int>(eb.pos_emb_in->ne[1]);
 
-        // Position of "relative offset 0" in the buffer: (pos_len-1)/2 for
-        // full / chunked_limited; W_left for Regular local attention.
+        // Position of relative offset 0 in the buffer: (pos_len-1)/2 for
+        // full/dense ChunkedLimited; W_left for Regular local attention;
+        // key_window-1 for the rectangular windowed ChunkedLimited graph.
         const bool is_chunked = (pm->hparams.enc_att_context_style == ParakeetHParams::AttContextStyle::ChunkedLimited);
         const bool is_local_pe =
             (!is_chunked) && (pm->hparams.enc_att_context_left >= 0 && pm->hparams.enc_att_context_right >= 0);
-        const int zero_index = is_local_pe ? pm->hparams.enc_att_context_left : (pos_len - 1) / 2;
+        const bool is_windowed_chunked = is_chunked && eb.chunked_mask_in != nullptr && eb.chunked_mask_in->ne[3] > 1;
+        const int  zero_index          = is_windowed_chunked ? static_cast<int>(eb.chunked_mask_in->ne[0]) - 1 :
+                                         is_local_pe         ? pm->hparams.enc_att_context_left :
+                                                               (pos_len - 1) / 2;
 
         pc->pos_buf.assign(static_cast<size_t>(pos_len) * d_model, 0.0f);
 
@@ -1063,22 +1069,28 @@ static transcribe_status run_one_shot_inner(ParakeetSession *             pc,
     // -INF outside. NeMo: chunk_size = att_context_right + 1,
     // left_chunks = att_context_left / chunk_size.
     if (eb.chunked_mask_in != nullptr) {
-        const int T_enc       = static_cast<int>(eb.chunked_mask_in->ne[0]);
         const int chunk_size  = pm->hparams.enc_att_context_right + 1;
         const int left_chunks = (chunk_size > 0) ? (pm->hparams.enc_att_context_left / chunk_size) : 0;
 
-        std::vector<float> mask_buf(static_cast<size_t>(T_enc) * static_cast<size_t>(T_enc));
-        // ggml ne = [T_k, T_q, 1, 1], row-major in the host buffer is
-        // contiguous along T_k (ne[0]). Indexing: mask[q, k] lives at
-        // offset (q * T_enc + k).
-        for (int q = 0; q < T_enc; ++q) {
-            const int q_chunk     = (chunk_size > 0) ? (q / chunk_size) : 0;
-            const int k_min_chunk = (q_chunk - left_chunks > 0) ? (q_chunk - left_chunks) : 0;
-            const int k_min       = k_min_chunk * chunk_size;
-            const int k_max       = (q_chunk + 1) * chunk_size;  // exclusive
-            float *   row         = mask_buf.data() + static_cast<size_t>(q) * T_enc;
-            for (int k = 0; k < T_enc; ++k) {
-                row[k] = (k >= k_min && k < k_max) ? 0.0f : -std::numeric_limits<float>::infinity();
+        const int          T_enc    = static_cast<int>(eb.out->ne[1]);
+        const int          T_k      = static_cast<int>(eb.chunked_mask_in->ne[0]);
+        const int          T_q      = static_cast<int>(eb.chunked_mask_in->ne[1]);
+        const int          N        = static_cast<int>(eb.chunked_mask_in->ne[3]);
+        const bool         windowed = N > 1;
+        std::vector<float> mask_buf(static_cast<size_t>(T_k) * T_q * N, -std::numeric_limits<float>::infinity());
+        if (windowed) {
+            compute_chunked_limited_window_mask(mask_buf.data(), T_enc, chunk_size, left_chunks);
+        } else {
+            // Dense reference layout [T_k,T_q,1,1].
+            for (int q = 0; q < T_enc; ++q) {
+                const int q_chunk     = (chunk_size > 0) ? (q / chunk_size) : 0;
+                const int k_min_chunk = (q_chunk - left_chunks > 0) ? (q_chunk - left_chunks) : 0;
+                const int k_min       = k_min_chunk * chunk_size;
+                const int k_max       = (q_chunk + 1) * chunk_size;  // exclusive
+                float *   row         = mask_buf.data() + static_cast<size_t>(q) * T_enc;
+                for (int k = 0; k < T_enc; ++k) {
+                    row[k] = (k >= k_min && k < k_max) ? 0.0f : -std::numeric_limits<float>::infinity();
+                }
             }
         }
 
@@ -1242,6 +1254,7 @@ static transcribe_status run_batch_encode(ParakeetSession *                     
     transcribe::pack_pad_channel_major(pc->mel_buf, mels, nf, n_mels, T_max);
 
     if (pc->compute_ctx != nullptr) {
+        pc->stream_graph.reset();
         ggml_free(pc->compute_ctx);
         pc->compute_ctx = nullptr;
     }
@@ -1647,6 +1660,11 @@ transcribe_status ensure_pos_proj_cache(ParakeetSession * pc, ParakeetModel * pm
         return TRANSCRIBE_ERR_BACKEND;
     }
 
+    // The steady-state encoder graph borrows the projection tensors below,
+    // and this one-off graph resets the scheduler allocation. It cannot be
+    // replayed after either operation.
+    pc->stream_graph.reset();
+
     auto & sc = pc->stream_caches;
     if (sc.pos_proj_buf != nullptr) {
         safe_buffer_free(sc.pos_proj_buf);
@@ -1763,6 +1781,38 @@ void compute_chunked_limited_with_rc_mask(float * out_buf,
     }
 }
 
+void compute_chunked_limited_window_mask(float * out_buf, int T, int chunk_size, int left_chunks) {
+    assert(out_buf != nullptr);
+    assert(T >= 1);
+    assert(chunk_size >= 1);
+    assert(left_chunks >= 0);
+
+    const int C = chunk_size;
+    const int W = (left_chunks + 1) * C;
+    const int N = (T + C - 1) / C;
+
+    std::fill(out_buf, out_buf + static_cast<size_t>(W) * C * N, -std::numeric_limits<float>::infinity());
+    for (int n = 0; n < N; ++n) {
+        const int key_start = (n - left_chunks) * C;
+        for (int q = 0; q < C; ++q) {
+            const int q_abs = n * C + q;
+            float *   row   = out_buf + (static_cast<size_t>(n) * C + q) * W;
+            if (q_abs >= T) {
+                // Kept finite only so softmax does not receive an all-masked
+                // row. The graph drops these padded query outputs.
+                row[0] = 0.0f;
+                continue;
+            }
+            for (int k = 0; k < W; ++k) {
+                const int k_abs = key_start + k;
+                if (k_abs >= 0 && k_abs < T) {
+                    row[k] = 0.0f;
+                }
+            }
+        }
+    }
+}
+
 namespace {
 
 // Build, run, and post-process a single streaming encoder chunk.
@@ -1791,21 +1841,6 @@ transcribe_status emit_streaming_chunk(ParakeetSession * pc,
     }
     if (pc->kv_type == TRANSCRIBE_KV_TYPE_F16) {
         resolved_kv = GGML_TYPE_F16;
-    }
-
-    // One compute_ctx per chunk (matches the offline run() lifecycle).
-    if (pc->compute_ctx != nullptr) {
-        ggml_free(pc->compute_ctx);
-        pc->compute_ctx = nullptr;
-    }
-    ggml_init_params ip{};
-    ip.mem_size     = 16 * 1024 * 1024;
-    ip.mem_buffer   = nullptr;
-    ip.no_alloc     = true;
-    pc->compute_ctx = ggml_init(ip);
-    if (pc->compute_ctx == nullptr) {
-        log_msg(TRANSCRIBE_LOG_LEVEL_ERROR, "parakeet stream: ggml_init compute_ctx failed");
-        return TRANSCRIBE_ERR_OOM;
     }
 
     const int  step_num = pc->stream_caches.chunk_step;
@@ -1853,25 +1888,82 @@ transcribe_status emit_streaming_chunk(ParakeetSession * pc,
     cache_io.pos_proj     = pc->stream_caches.pos_proj;
     cache_io.pos_proj_len = pc->stream_caches.pos_proj_len;
 
-    EncoderBuild eb = build_encoder_graph_streaming(pc->compute_ctx, pm->weights, hp, n_mel_chunk_frames,
-                                                    drop_extra_pre_encoded, cache_io, resolved_kv, pm->backend.c_str());
-    if (eb.out == nullptr || eb.graph == nullptr) {
-        return TRANSCRIBE_ERR_GGUF;
-    }
+    auto &     graph_cache = pc->stream_graph;
+    const bool reuse_graph = !dump_on && graph_cache.ready && pc->compute_ctx != nullptr && pc->sched != nullptr &&
+                             graph_cache.n_mel_chunk_frames == n_mel_chunk_frames &&
+                             graph_cache.drop_extra_pre_encoded == drop_extra_pre_encoded &&
+                             graph_cache.pos_proj_len == cache_io.pos_proj_len &&
+                             graph_cache.kv_type == static_cast<int>(resolved_kv);
 
-    if (pc->sched == nullptr) {
-        pc->sched = ggml_backend_sched_new(pm->plan.scheduler_list.data(), nullptr,
-                                           static_cast<int>(pm->plan.scheduler_list.size()),
-                                           /*graph_size=*/8192, /*parallel=*/false, /*op_offload=*/true);
+    EncoderBuild eb;
+    if (reuse_graph) {
+        eb.graph             = graph_cache.graph;
+        eb.mel_in            = graph_cache.mel_in;
+        eb.pos_emb_in        = graph_cache.pos_emb_in;
+        eb.chunked_mask_in   = graph_cache.chunked_mask_in;
+        eb.prompt_one_hot_in = graph_cache.prompt_one_hot_in;
+        eb.out               = graph_cache.out;
+        cache_io.channel_out = graph_cache.channel_out;
+        cache_io.time_out    = graph_cache.time_out;
+        cache_io.k_out       = graph_cache.k_out;
+        cache_io.v_out       = graph_cache.v_out;
+    } else {
+        graph_cache.reset();
+        if (pc->compute_ctx != nullptr) {
+            ggml_free(pc->compute_ctx);
+            pc->compute_ctx = nullptr;
+        }
+        ggml_init_params ip{};
+        ip.mem_size     = 16 * 1024 * 1024;
+        ip.mem_buffer   = nullptr;
+        ip.no_alloc     = true;
+        pc->compute_ctx = ggml_init(ip);
+        if (pc->compute_ctx == nullptr) {
+            log_msg(TRANSCRIBE_LOG_LEVEL_ERROR, "parakeet stream: ggml_init compute_ctx failed");
+            return TRANSCRIBE_ERR_OOM;
+        }
+
+        eb = build_encoder_graph_streaming(pc->compute_ctx, pm->weights, hp, n_mel_chunk_frames, drop_extra_pre_encoded,
+                                           cache_io, resolved_kv, pm->backend.c_str());
+        if (eb.out == nullptr || eb.graph == nullptr) {
+            return TRANSCRIBE_ERR_GGUF;
+        }
+
         if (pc->sched == nullptr) {
-            log_msg(TRANSCRIBE_LOG_LEVEL_ERROR, "parakeet stream: sched_new failed");
+            pc->sched = ggml_backend_sched_new(pm->plan.scheduler_list.data(), nullptr,
+                                               static_cast<int>(pm->plan.scheduler_list.size()),
+                                               /*graph_size=*/8192, /*parallel=*/false, /*op_offload=*/true);
+            if (pc->sched == nullptr) {
+                log_msg(TRANSCRIBE_LOG_LEVEL_ERROR, "parakeet stream: sched_new failed");
+                return TRANSCRIBE_ERR_BACKEND;
+            }
+        }
+        ggml_backend_sched_reset(pc->sched);
+        if (!ggml_backend_sched_alloc_graph(pc->sched, eb.graph)) {
+            log_msg(TRANSCRIBE_LOG_LEVEL_ERROR, "parakeet stream: alloc_graph failed");
             return TRANSCRIBE_ERR_BACKEND;
         }
-    }
-    ggml_backend_sched_reset(pc->sched);
-    if (!ggml_backend_sched_alloc_graph(pc->sched, eb.graph)) {
-        log_msg(TRANSCRIBE_LOG_LEVEL_ERROR, "parakeet stream: alloc_graph failed");
-        return TRANSCRIBE_ERR_BACKEND;
+
+        // A geometry whose rel-pos projections are already memoized is
+        // stable across chunks. Keep its allocated graph and replay it on
+        // the next chunk after refreshing the mutable inputs and caches.
+        if (!dump_on && eb.pos_emb_in == nullptr) {
+            graph_cache.graph                  = eb.graph;
+            graph_cache.mel_in                 = eb.mel_in;
+            graph_cache.pos_emb_in             = eb.pos_emb_in;
+            graph_cache.chunked_mask_in        = eb.chunked_mask_in;
+            graph_cache.prompt_one_hot_in      = eb.prompt_one_hot_in;
+            graph_cache.out                    = eb.out;
+            graph_cache.channel_out            = cache_io.channel_out;
+            graph_cache.time_out               = cache_io.time_out;
+            graph_cache.k_out                  = cache_io.k_out;
+            graph_cache.v_out                  = cache_io.v_out;
+            graph_cache.n_mel_chunk_frames     = n_mel_chunk_frames;
+            graph_cache.drop_extra_pre_encoded = drop_extra_pre_encoded;
+            graph_cache.pos_proj_len           = cache_io.pos_proj_len;
+            graph_cache.kv_type                = static_cast<int>(resolved_kv);
+            graph_cache.ready                  = true;
+        }
     }
 
     // Upload mel chunk. Row-major [n_mels, n_mel_chunk_frames] is
@@ -1927,6 +2019,7 @@ transcribe_status emit_streaming_chunk(ParakeetSession * pc,
     transcribe::configure_sched_n_threads(pc->sched, pc->n_threads);
 
     if (const ggml_status gs = ggml_backend_sched_graph_compute(pc->sched, eb.graph); gs != GGML_STATUS_SUCCESS) {
+        graph_cache.reset();
         log_msg(TRANSCRIBE_LOG_LEVEL_ERROR, "parakeet stream: graph_compute failed (%d)", static_cast<int>(gs));
         return TRANSCRIBE_ERR_GGUF;
     }
@@ -2186,6 +2279,7 @@ transcribe_status emit_buffered_chunk(ParakeetSession * pc,
 
     // ----- Reset per-chunk compute state -----
     if (pc->compute_ctx != nullptr) {
+        pc->stream_graph.reset();
         ggml_free(pc->compute_ctx);
         pc->compute_ctx = nullptr;
     }

--- a/src/arch/parakeet/parakeet.h
+++ b/src/arch/parakeet/parakeet.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 struct ggml_context;
+struct ggml_cgraph;
 struct ggml_tensor;
 struct ggml_backend;
 struct ggml_backend_buffer;
@@ -36,7 +37,7 @@ inline int pre_encode_time_out(int input_frames, bool causal) {
     return causal ? (input_frames / 2 + 1) : ((input_frames - 1) / 2 + 1);
 }
 
-// Host-side attention-mask helpers for the streaming paths. Declared
+// Host-side attention-mask helpers for the chunked-attention paths. Declared
 // here so the per-mask unit tests can call them without a ggml backend
 // or a GGUF on disk.
 //
@@ -61,6 +62,16 @@ void compute_chunked_limited_with_rc_mask(float * out_buf,
                                           int     chunk_size_frames,
                                           int     right_context_frames,
                                           int     pad_length);
+
+// Bounded offline ChunkedLimited mask. The dense mask has T*T cells, but
+// every query chunk only attends to `left_chunks` complete chunks on its
+// left plus itself. This helper emits the equivalent compact layout used by
+// rel_pos_mhsa: [window, chunk_size, 1, n_chunks], contiguous in `window`,
+// where window = (left_chunks + 1)*chunk_size and
+// n_chunks = ceil(T/chunk_size). Prefix/tail K padding is -INF. Padded query
+// rows retain one finite cell to avoid an all-masked softmax; those rows are
+// removed from the graph output before the residual path.
+void compute_chunked_limited_window_mask(float * out_buf, int T, int chunk_size, int left_chunks);
 
 // Family defaults — applied before transcribe::read_capability_kv runs
 // (KV present overrides, KV absent leaves the default). Defined in
@@ -216,6 +227,50 @@ struct ParakeetStreamingDecoderState {
     bool initialized = false;
 };
 
+// Scheduler-allocated steady-state streaming graph. ggml graphs are
+// multi-use for computation once allocated; retaining the fixed-geometry
+// graph avoids rebuilding and re-allocating the same encoder topology for
+// every chunk. All tensor handles are borrowed from compute_ctx and become
+// invalid together when reset() is called before that context is freed.
+struct ParakeetStreamingGraph {
+    ggml_cgraph * graph = nullptr;
+
+    ggml_tensor * mel_in            = nullptr;
+    ggml_tensor * pos_emb_in        = nullptr;
+    ggml_tensor * chunked_mask_in   = nullptr;
+    ggml_tensor * prompt_one_hot_in = nullptr;
+    ggml_tensor * out               = nullptr;
+
+    std::vector<ggml_tensor *> channel_out;
+    std::vector<ggml_tensor *> time_out;
+    std::vector<ggml_tensor *> k_out;
+    std::vector<ggml_tensor *> v_out;
+
+    int  n_mel_chunk_frames     = -1;
+    int  drop_extra_pre_encoded = -1;
+    int  pos_proj_len           = -1;
+    int  kv_type                = -1;
+    bool ready                  = false;
+
+    void reset() {
+        graph                  = nullptr;
+        mel_in                 = nullptr;
+        pos_emb_in             = nullptr;
+        chunked_mask_in        = nullptr;
+        prompt_one_hot_in      = nullptr;
+        out                    = nullptr;
+        n_mel_chunk_frames     = -1;
+        drop_extra_pre_encoded = -1;
+        pos_proj_len           = -1;
+        kv_type                = -1;
+        ready                  = false;
+        channel_out.clear();
+        time_out.clear();
+        k_out.clear();
+        v_out.clear();
+    }
+};
+
 // Concrete context. Owns a per-call compute context and a persistent
 // multi-backend scheduler that dispatches encoder graph ops to the best
 // available backend.
@@ -259,6 +314,7 @@ struct ParakeetSession final : public transcribe_session {
     // an utterance, freed in the dtor.
     ParakeetStreamingCaches       stream_caches;
     ParakeetStreamingDecoderState stream_dec_state;
+    ParakeetStreamingGraph        stream_graph;
 
     // ---- Buffered streaming state (parakeet-unified-en-0.6b) ----
     //

--- a/src/conformer/conformer.cpp
+++ b/src/conformer/conformer.cpp
@@ -593,6 +593,131 @@ ggml_tensor * rel_pos_mhsa(ggml_context *      ctx,
     }
     ggml_tensor * p = pos_proj == nullptr ? ggml_mul_mat(ctx, b.attn_pos_w, pos_emb) : nullptr;
 
+    // Long offline ChunkedLimited utterances have a block mask: every
+    // chunk of C queries attends to the current chunk plus a fixed number
+    // of complete chunks on its left. Reframe those blocks as a batch of
+    // rectangular attention problems instead of materializing T-by-T
+    // scores. Q/K/V projections still run once over the whole utterance;
+    // only the bounded attention windows are replicated.
+    if (params.chunked_windowed) {
+        const int64_t C           = att_context_right + 1;
+        const int64_t left_chunks = C > 0 ? att_context_left / C : 0;
+        const int64_t W           = (left_chunks + 1) * C;
+        const int64_t T           = x->ne[1];
+        const int64_t N           = C > 0 ? (T + C - 1) / C : 0;
+        const int64_t T_pad       = N * C;
+        const int64_t pad_right   = T_pad - T;
+
+        if (rect || B != 1 || C <= 0 || W <= 0 || N <= 0 || pos_len != W + C - 1 ||
+            params.attn_chunked_mask == nullptr || params.attn_chunked_mask->ne[0] != W ||
+            params.attn_chunked_mask->ne[1] != C || params.attn_chunked_mask->ne[3] != N) {
+            std::fprintf(stderr,
+                         "conformer rel_pos_mhsa: invalid windowed chunk "
+                         "geometry (T=%lld C=%lld W=%lld N=%lld pos=%lld)\n",
+                         (long long) T, (long long) C, (long long) W, (long long) N, (long long) pos_len);
+            return nullptr;
+        }
+
+        q                 = ggml_reshape_4d(ctx, q, head_dim, n_head, T, 1);
+        ggml_tensor * q_u = ggml_add(ctx, q, b.attn_pos_u);
+        ggml_tensor * q_v = ggml_add(ctx, q, b.attn_pos_v);
+
+        // Pad on the time axis while it is ne[2], then move time next to
+        // head_dim and reinterpret query chunks as batch N.
+        q_u = ggml_pad_ext(ctx, q_u, 0, 0, 0, 0, 0, static_cast<int>(pad_right), 0, 0);
+        q_v = ggml_pad_ext(ctx, q_v, 0, 0, 0, 0, 0, static_cast<int>(pad_right), 0, 0);
+        q_u = ggml_cont(ctx, ggml_permute(ctx, q_u, 0, 2, 1, 3));
+        q_v = ggml_cont(ctx, ggml_permute(ctx, q_v, 0, 2, 1, 3));
+        q_u = ggml_reshape_4d(ctx, q_u, head_dim, C, N, n_head);
+        q_v = ggml_reshape_4d(ctx, q_v, head_dim, C, N, n_head);
+        q_u = ggml_cont(ctx, ggml_permute(ctx, q_u, 0, 1, 3, 2));
+        q_v = ggml_cont(ctx, ggml_permute(ctx, q_v, 0, 1, 3, 2));
+
+        // Materialize overlapping K/V windows with the existing 1-D
+        // im2col op. Pad the ragged tail to a complete chunk first;
+        // symmetric left-context padding then produces a few unused windows
+        // on the right, which are sliced before [head_dim,W,head,N].
+        const int left_pad       = static_cast<int>(left_chunks * C);
+        ggml_type window_kv_type = GGML_TYPE_F32;
+        if (use_flash) {
+            window_kv_type = kv_type;
+            if (window_kv_type == GGML_TYPE_COUNT) {
+                window_kv_type = (b.attn_k_w->type != GGML_TYPE_F32) ? GGML_TYPE_F16 : GGML_TYPE_F32;
+            }
+            if (window_kv_type != GGML_TYPE_F16 && window_kv_type != GGML_TYPE_F32) {
+                window_kv_type = GGML_TYPE_F32;
+            }
+        }
+        auto window_kv = [&](ggml_tensor * t) -> ggml_tensor * {
+            t = ggml_reshape_4d(ctx, t, head_dim, n_head, T, 1);
+            if (pad_right > 0) {
+                t = ggml_pad_ext(ctx, t, 0, 0, 0, 0, 0, static_cast<int>(pad_right), 0, 0);
+            }
+            t = ggml_cont(ctx, ggml_permute(ctx, t, 0, 2, 1, 3));
+            t = ggml_cont(ctx, ggml_permute(ctx, t, 1, 0, 2, 3));  // [T,head_dim,n_head]
+
+            ggml_tensor * kernel_shape =
+                ggml_new_tensor_3d(ctx, window_kv_type, W, head_dim, 1);  // shape-only im2col source
+            ggml_tensor * cols = ggml_im2col(ctx, kernel_shape, t, static_cast<int>(C), 0, left_pad, 0, 1, 0,
+                                             /*is_2D=*/false, window_kv_type);
+            if (cols->ne[1] < N) {
+                return nullptr;
+            }
+            if (cols->ne[1] > N) {
+                cols = ggml_view_4d(ctx, cols, head_dim * W, N, n_head, 1, cols->nb[1], cols->nb[2], cols->nb[3], 0);
+                cols = ggml_cont(ctx, cols);
+            }
+            cols = ggml_reshape_4d(ctx, cols, W, head_dim, N, n_head);
+            return ggml_cont(ctx, ggml_permute(ctx, cols, 1, 0, 3, 2));
+        };
+        k = window_kv(k);
+        v = window_kv(v);
+        if (k == nullptr || v == nullptr) {
+            std::fprintf(stderr, "conformer rel_pos_mhsa: im2col produced too few chunk windows\n");
+            return nullptr;
+        }
+
+        p = ggml_reshape_4d(ctx, p, head_dim, n_head, pos_len, 1);
+        p = ggml_cont(ctx, ggml_permute(ctx, p, 0, 2, 1, 3));
+
+        ggml_tensor * matrix_bd = ggml_mul_mat(ctx, p, q_v);
+        matrix_bd               = rel_shift(ctx, matrix_bd);
+        matrix_bd =
+            ggml_view_4d(ctx, matrix_bd, W, C, n_head, N, matrix_bd->nb[1], matrix_bd->nb[2], matrix_bd->nb[3], 0);
+        matrix_bd = ggml_add(ctx, matrix_bd, params.attn_chunked_mask);
+
+        ggml_tensor * o = nullptr;
+        if (use_flash) {
+            matrix_bd = ggml_scale(ctx, ggml_cont(ctx, matrix_bd), scale);
+            matrix_bd = ggml_cast(ctx, matrix_bd, GGML_TYPE_F16);
+
+            o = ggml_flash_attn_ext(ctx, q_u, k, v, matrix_bd, scale, /*max_bias=*/0.0f,
+                                    /*logit_softcap=*/0.0f);
+        } else {
+            ggml_tensor * kq      = ggml_mul_mat(ctx, k, q_u);
+            kq                    = ggml_add(ctx, kq, matrix_bd);
+            ggml_tensor * kq_soft = ggml_soft_max_ext(ctx, kq, /*mask=*/nullptr, scale, /*max_bias=*/0.0f);
+            ggml_tensor * v_t     = ggml_cont(ctx, ggml_permute(ctx, v, 1, 0, 2, 3));
+            o                     = ggml_mul_mat(ctx, v_t, kq_soft);
+            o                     = ggml_cont(ctx, ggml_permute(ctx, o, 0, 2, 1, 3));
+        }
+
+        // Both branches now have [head_dim,n_head,C,N]. Merge heads and
+        // flatten chunk batch back to the original time axis, dropping the
+        // padded tail before the output projection/residual.
+        o = ggml_reshape_3d(ctx, o, d_model, C, N);
+        o = ggml_reshape_3d(ctx, o, d_model, T_pad, 1);
+        if (pad_right > 0) {
+            o = ggml_view_3d(ctx, o, d_model, T, 1, o->nb[1], o->nb[2], 0);
+            o = ggml_cont(ctx, o);
+        }
+        o = ggml_mul_mat(ctx, b.attn_out_w, o);
+        if (b.attn_out_b != nullptr) {
+            o = ggml_add(ctx, o, b.attn_out_b);
+        }
+        return o;
+    }
+
     // Split heads: [head_dim, n_head, T, B] (batch at ne[3]). pos_bias_u/v
     // broadcast onto this BEFORE the permute that moves T past n_head.
     q                 = ggml_reshape_4d(ctx, q, head_dim, n_head, T_q, B);

--- a/src/conformer/conformer.h
+++ b/src/conformer/conformer.h
@@ -163,8 +163,8 @@ struct BlockParams {
     //     T <= 2W+1 and remains correct (band-restricted) when T
     //     exceeds the window. Default for every offline variant.
     //
-    //   ChunkedLimited  — pos_emb stays at the full 2T-1 length and
-    //     the caller supplies a precomputed F16 mask of shape
+    //   ChunkedLimited  — pos_emb normally stays at the full 2T-1 length
+    //     and the caller supplies a precomputed F32 mask of shape
     //     [T_k, T_q, 1, 1] in `attn_chunked_mask` that
     //     rel_pos_mhsa adds onto matrix_bd before flash_attn. Chunk
     //     size = right+1, left_chunks = left/chunk_size; the mask is
@@ -173,8 +173,15 @@ struct BlockParams {
     enum class AttContextStyle { Regular, ChunkedLimited };
     AttContextStyle att_context_style = AttContextStyle::Regular;
 
+    // Offline ChunkedLimited optimization. When true, attention reshapes
+    // one utterance into a batch of fixed-size query chunks and overlapping
+    // bounded K/V windows. This is mathematically the same mask as the dense
+    // [T,T] path, but its work and temporary storage are linear in T.
+    // attn_chunked_mask is [window, chunk, 1, n_chunks] in this mode.
+    bool chunked_windowed = false;
+
     // Optional precomputed mask for ChunkedLimited. The caller builds
-    // this as a graph input shape [T_k, T_q, 1, 1] F16 (broadcasts
+    // this as a graph input shape [T_k, T_q, 1, 1] F32 (broadcasts
     // across heads) and uploads the host-computed pattern after the
     // compute buffer is allocated. Ignored for AttContextStyle::Regular.
     ggml_tensor * attn_chunked_mask = nullptr;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -170,6 +170,24 @@ transcribe_apply_warnings(transcribe_parakeet_chunked_limited_with_rc_mask_unit)
 add_test(NAME transcribe_parakeet_chunked_limited_with_rc_mask_unit
     COMMAND transcribe_parakeet_chunked_limited_with_rc_mask_unit)
 
+# Compact offline ChunkedLimited attention mask. Proves that the bounded
+# [window,chunk,n_chunks] representation reconstructs the original dense
+# [T,T] chunk topology and relative-position offsets for ragged geometries.
+
+add_executable(transcribe_parakeet_chunked_limited_window_mask_unit
+    parakeet_chunked_limited_window_mask_unit.cpp)
+
+target_link_libraries(transcribe_parakeet_chunked_limited_window_mask_unit
+    PRIVATE transcribe ggml)
+
+target_include_directories(transcribe_parakeet_chunked_limited_window_mask_unit
+    PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+transcribe_apply_warnings(transcribe_parakeet_chunked_limited_window_mask_unit)
+
+add_test(NAME transcribe_parakeet_chunked_limited_window_mask_unit
+    COMMAND transcribe_parakeet_chunked_limited_window_mask_unit)
+
 # -----------------------------------------------------------------------------
 # Variable-length batch mask and causal subsampling unit test
 # -----------------------------------------------------------------------------

--- a/tests/parakeet_chunked_limited_window_mask_unit.cpp
+++ b/tests/parakeet_chunked_limited_window_mask_unit.cpp
@@ -1,0 +1,120 @@
+// parakeet_chunked_limited_window_mask_unit.cpp - equivalence test for the
+// compact offline ChunkedLimited attention mask.
+
+#include "arch/parakeet/parakeet.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+bool is_masked(float value) {
+    return std::isinf(value) && value < 0.0f;
+}
+
+void fail_case(const char * reason, int T, int C, int left_chunks, int q, int k) {
+    if (g_failures < 12) {
+        std::fprintf(stderr, "FAIL %s: T=%d C=%d left_chunks=%d q=%d k=%d\n", reason, T, C, left_chunks, q, k);
+    }
+    ++g_failures;
+}
+
+void run_case(int T, int C, int left_chunks) {
+    const int W = (left_chunks + 1) * C;
+    const int N = (T + C - 1) / C;
+
+    // The graph pads T to N*C before im2col. With symmetric left padding,
+    // its first N windows must exist and begin at exactly the same absolute
+    // key positions as the compact host mask.
+    const int T_pad          = N * C;
+    const int left_pad       = left_chunks * C;
+    const int im2col_windows = (T_pad + 2 * left_pad - W) / C + 1;
+    if (im2col_windows < N) {
+        fail_case("im2col window count", T, C, left_chunks, -1, im2col_windows);
+    }
+
+    std::vector<float> compact(static_cast<size_t>(W) * C * N);
+    transcribe::parakeet::compute_chunked_limited_window_mask(compact.data(), T, C, left_chunks);
+
+    for (int n = 0; n < N; ++n) {
+        const int key_start = (n - left_chunks) * C;
+        if (n * C - left_pad != key_start) {
+            fail_case("im2col window origin", T, C, left_chunks, n, key_start);
+        }
+        for (int q_local = 0; q_local < C; ++q_local) {
+            const int     q_abs = n * C + q_local;
+            const float * row   = compact.data() + (static_cast<size_t>(n) * C + q_local) * W;
+
+            if (q_abs >= T) {
+                // Padded queries are discarded, but must contain exactly one
+                // finite score so softmax never sees an all-masked row.
+                for (int k_local = 0; k_local < W; ++k_local) {
+                    const bool expected_finite = k_local == 0;
+                    const bool got_finite      = row[k_local] == 0.0f;
+                    if (expected_finite != got_finite || (!got_finite && !is_masked(row[k_local]))) {
+                        fail_case("padded query sentinel", T, C, left_chunks, q_abs, k_local);
+                    }
+                }
+                continue;
+            }
+
+            // Reconstruct every dense [q,k] cell from the compact row and
+            // compare it with the original chunk-index formula.
+            for (int k_abs = 0; k_abs < T; ++k_abs) {
+                const int  k_local         = k_abs - key_start;
+                const bool compact_allowed = k_local >= 0 && k_local < W && row[k_local] == 0.0f;
+                const int  k_chunk         = k_abs / C;
+                const bool dense_allowed   = k_chunk >= (n - left_chunks > 0 ? n - left_chunks : 0) && k_chunk <= n;
+                if (compact_allowed != dense_allowed) {
+                    fail_case("dense equivalence", T, C, left_chunks, q_abs, k_abs);
+                }
+            }
+
+            for (int k_local = 0; k_local < W; ++k_local) {
+                const int  k_abs           = key_start + k_local;
+                const bool expected_finite = k_abs >= 0 && k_abs < T;
+                const bool got_finite      = row[k_local] == 0.0f;
+                if (expected_finite != got_finite || (!got_finite && !is_masked(row[k_local]))) {
+                    fail_case("window padding", T, C, left_chunks, q_abs, k_abs);
+                }
+
+                // The shortened positional table must address the same
+                // q_abs-k_abs offset as the dense 2*T-1 table. rel_shift
+                // selects source row k_local-q_local+C-1.
+                const int source_row    = k_local - q_local + C - 1;
+                const int zero_row      = W - 1;
+                const int compact_delta = zero_row - source_row;
+                if (compact_delta != q_abs - k_abs) {
+                    fail_case("relative position", T, C, left_chunks, q_abs, k_abs);
+                }
+            }
+        }
+    }
+}
+
+}  // namespace
+
+int main() {
+    // Exhaust the awkward geometries around every chunk boundary and ragged
+    // tail. This includes the Nemotron 3.5 geometry (C=14, left_chunks=4)
+    // as well as much smaller windows that make off-by-one
+    // errors easier to expose.
+    for (int T = 1; T <= 97; ++T) {
+        for (int C = 1; C <= 16; ++C) {
+            for (int left_chunks = 0; left_chunks <= 6; ++left_chunks) {
+                run_case(T, C, left_chunks);
+            }
+        }
+    }
+
+    if (g_failures != 0) {
+        std::fprintf(stderr, "FAILED: %d mismatches\n", g_failures);
+        return EXIT_FAILURE;
+    }
+    std::fprintf(stderr, "OK\n");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary\n\n- Replace quadratic dense ChunkedLimited attention on long single-utterance Parakeet inputs with an equivalent batch of bounded query/key windows.\n- Keep the dense reference graph for short, batched, and tensor-debug runs; the bounded path starts only beyond the measured crossover.\n- Reuse the allocated steady-state cache-aware streaming graph instead of rebuilding it for every chunk.\n\nFor the Nemotron 3.5 geometry, each 14-frame query chunk attends to a 70-frame K/V window. This changes attention score work and temporary storage from O(T*T) to O(T*W), while preserving the original chunk topology and relative-position offsets.\n\n## Scope\n\n- src/arch/parakeet: offline graph selection, compact masks and positional embeddings, streaming graph lifecycle/replay\n- src/conformer: bounded relative-position attention using portable ggml reshape, pad, im2col, and flash/manual attention operations\n- tests: exhaustive compact-mask, im2col-window, and relative-position equivalence coverage\n\n## AI Assistance\n\nCodex meaningfully assisted with profiling, implementation, test construction, numerical comparison, and benchmark analysis. I reviewed and validated the resulting change and own the contribution.\n\n## Validation\n\n- scripts/ci/clang-format.sh --check\n- cmake --build build --target transcribe-cli\n- ctest --test-dir build --output-on-failure -j8: 34/34 passed\n- uv run scripts/validate.py cpp --family parakeet --variant nemotron-3.5-asr-streaming-0.6b --gguf models/nemotron-3.5-asr-streaming-0.6b/nemotron-3.5-asr-streaming-0.6b-F16.gguf --backend metal\n- Q8_0 and F16 Metal inference, Q8_0 CPU fallback, short/dense and long/bounded paths\n- Cache-aware streaming R=0,3,6,13: output identical to the pre-change binary\n- ctm-transcribe integration tests: 5/5 passed, including real-model Metal smoke\n\nApple M4 Max, Q8_0, 557.56-second WAV:\n\n- HTTP end-to-end: 23.54 s before, 10.21-10.90 s after (2.2-2.3x)\n- Encoder: 19.38 s before, approximately 5.3 s after (approximately 3.6x)\n- Transcript text and token count are identical.\n- Direct tensor comparison showed final encoder mean absolute drift of 2.09e-5 under Metal flash attention. One token boundary moved by 80 ms because the bounded geometry selects a different Metal reduction kernel.\n\nThe new mask unit test exhaustively compares more than 10,000 combinations of sequence length, chunk size, left context, prefix padding, ragged tails, im2col origins, and relative-position indices against the dense formula.\n\nA corpus-level WER run is still recommended because floating-point reduction order changes, even though the attention topology is exactly equivalent and the tested transcripts remain identical.