### PR TITLE
Windows: link manifest records Vulkan import lib as `vulkan`, breaking non-CMake consumers (LNK1181)

### DIFF
--- a/cmake/transcribe-install.cmake
+++ b/cmake/transcribe-install.cmake
@@ -135,7 +135,18 @@ if(NOT TRANSCRIBE_BUILD_SHARED)
         list(APPEND _frameworks Accelerate)
     endif()
     if("vulkan" IN_LIST _kinds)
-        list(APPEND _system_libs vulkan)
+        # The Vulkan import library's basename is platform-specific: Windows'
+        # LunarG SDK ships `vulkan-1.lib` (the import lib for the
+        # driver-installed vulkan-1.dll loader); every other platform links
+        # `libvulkan`. Emit the right name per-OS so a non-CMake consumer
+        # reconstructing the link line from this manifest resolves it — a bare
+        # `vulkan` becomes `vulkan.lib` on MSVC, which the SDK does not provide,
+        # so the link dies with LNK1181.
+        if(WIN32)
+            list(APPEND _system_libs vulkan-1)
+        else()
+            list(APPEND _system_libs vulkan)
+        endif()
     endif()
     if(_frameworks)
         list(REMOVE_DUPLICATES _frameworks)


### PR DESCRIPTION
`cmake/transcribe-install.cmake` writes `vulkan` into `transcribe-link.json`'s `system_libs` on every OS, but Windows' LunarG SDK ships the import lib as `vulkan-1.lib` — so a consumer reconstructing the link line from the manifest (the Rust `-sys` crate, the `link_smoke` C consumer) asks MSVC for a nonexistent `vulkan.lib` and dies with `LNK1181: cannot open input file 'vulkan.lib'`.

The in-tree ggml-vulkan target links fine because it uses `find_package(Vulkan)` → `Vulkan::Vulkan` (an absolute path); only the hand-written manifest reconstruction hardcodes the Unix basename.

**Fix:** emit `vulkan-1` under `if(WIN32)` and `vulkan` otherwise, matching how whisper-rs-sys resolves the same import lib. Non-Windows output is byte-identical.