### PR TITLE
Add Persian (Farsi) FastConformer Hybrid Large variant

### DIFF
--- a/scripts/convert-parakeet.py
+++ b/scripts/convert-parakeet.py
@@ -247,6 +247,30 @@ VARIANT_PROFILES: dict[str, dict] = {
         "license_name": "Creative Commons Attribution 4.0",
         "license_link": "https://creativecommons.org/licenses/by/4.0/",
     },
+    # 115M Persian (Farsi) hybrid RNNT+CTC FastConformer, from NVIDIA's
+    # nvidia/stt_fa_fastconformer_hybrid_large (Common Voice fa 15.0
+    # fine-tune of the English FastConformer encoder). Not an official
+    # transcribe.cpp-tracked Parakeet release; added locally to convert
+    # this checkpoint. We walk the CTC path (head_kind="ctc") rather
+    # than the RNNT decoder/joint, matching the simpler, well-tested
+    # parakeet-ctc-* code path and avoiding the autoregressive
+    # predictor/joint resolution for a model this codebase doesn't
+    # otherwise know about.
+    "stt-fa-fastconformer-hybrid-large": {
+        "variant": "fa-fastconformer-hybrid-large",
+        "display_name": "FastConformer Hybrid Large (Persian)",
+        "version": "v1",
+        "size_label": "115M",
+        "basename": "parakeet-ctc",
+        "head_kind": "ctc",
+        "ctc_from_aux": True,
+        "expected_vocab_size": 1024,
+        "languages": ["fa"],
+        "lang_detect": False,
+        "license": "cc-by-4.0",
+        "license_name": "Creative Commons Attribution 4.0",
+        "license_link": "https://creativecommons.org/licenses/by/4.0/",
+    },
     # 110M English hybrid TDT+CTC. Shipped as TDT-only at runtime
     # per the family-level Open-decisions #1 ("the pure ctc-* variants
     # cover the CTC path; drop the hybrid's auxiliary CTC head"). The
@@ -1222,13 +1246,25 @@ EXPECTED_UNUSED_PREFIXES_TDT_CTC_DROPPED = ("ctc_decoder.",)
 
 
 def is_expected_unused(key: str, head_kind: str, drop_aux_ctc: bool,
-                       has_prompt: bool) -> bool:
+                       has_prompt: bool, ctc_from_aux: bool = False) -> bool:
     if key.startswith(EXPECTED_UNUSED_PREFIXES_BASE):
         return True
     if key.endswith(EXPECTED_UNUSED_SUFFIXES):
         return True
     if drop_aux_ctc and key.startswith(EXPECTED_UNUSED_PREFIXES_TDT_CTC_DROPPED):
         return True
+    # Reverse case of the above: a hybrid checkpoint where we walk the
+    # CTC path (head_kind="ctc") and the *primary* decoder.{prediction,
+    # joint} tensors are the RNNT head we're deliberately not using.
+    # `ctc_decoder.*` itself is also expected-unused here: convert()
+    # aliased it onto `decoder.*` earlier (see the ctc_from_aux block
+    # above `sd_keys = set(sd.keys())`), so the original prefixed keys
+    # are consumed-by-copy rather than consumed-by-name.
+    if ctc_from_aux and head_kind == "ctc":
+        if key.startswith("decoder.prediction.") or key.startswith("joint."):
+            return True
+        if key.startswith("ctc_decoder."):
+            return True
     # prompt_kernel.* belongs to the multilingual prompt MLP. Variants
     # with has_prompt=True consume these via PROMPT_MLP_TABLE; variants
     # without the prompt path (English-only checkpoints) won't carry
@@ -1389,6 +1425,32 @@ def convert(model_spec: str, out_path: Path, repo_id: str | None = None) -> None
         )
 
     sd = model.state_dict()
+
+    # Hybrid checkpoints where we're walking the CTC path but the
+    # checkpoint's *primary* decoder is RNNT: the real CTC head lives
+    # under the auxiliary `ctc_decoder.` prefix (NeMo's
+    # EncDecHybridRNNTCTCModel convention), not under top-level
+    # `decoder.` (which here is the RNNT prediction network we are
+    # deliberately not using). Alias `ctc_decoder.*` -> `decoder.*` so
+    # CTC_HEAD_TABLE's fixed `decoder.decoder_layers.0.*` lookups
+    # resolve to the right tensors. Opt-in via the profile so this
+    # never silently touches the tdt_ctc-* variants (which drop
+    # ctc_decoder.* the other way around, see drop_aux_ctc above).
+    if profile.get("ctc_from_aux") and head_kind == "ctc":
+        aux_prefix = "ctc_decoder."
+        aliased = 0
+        for k in list(sd.keys()):
+            if k.startswith(aux_prefix):
+                sd["decoder." + k[len(aux_prefix):]] = sd[k]
+                aliased += 1
+        if aliased == 0:
+            raise KeyError(
+                f"ctc_from_aux=True but no {aux_prefix!r}-prefixed tensors "
+                f"found in state_dict"
+            )
+        print(f"Aliased {aliased} tensors from {aux_prefix!r} -> 'decoder.' "
+              f"for the CTC head")
+
     sd_keys = set(sd.keys())
 
     # Resolve enc_use_bias from the state_dict. The presence of
@@ -1798,7 +1860,8 @@ def convert(model_spec: str, out_path: Path, repo_id: str | None = None) -> None
 
     unused = sorted(
         k for k in (sd_keys - consumed)
-        if not is_expected_unused(k, head_kind, drop_aux_ctc, has_prompt)
+        if not is_expected_unused(k, head_kind, drop_aux_ctc, has_prompt,
+                                  bool(profile.get("ctc_from_aux", False)))
     )
     if unused:
         print(


### PR DESCRIPTION
## Why

Handy currently has no lightweight, CPU-only option for Persian (Farsi). The existing choices each have a real gap:

- **Whisper (small/medium)**: officially support Persian, but accuracy is noticeably weaker — Persian is a low-resource language in Whisper's training mix.
- **Whisper large-v3**: the first Whisper size with genuinely usable Persian accuracy, but it's GPU-bound. On a shared or modest GPU, model load and inference compete with everything else using the GPU, making it slow and inconsistent in practice — the opposite of the instant, CPU-only feel Canary/Parakeet give for their languages.
- **Other lightweight community options** (Vosk, wav2vec2-persian): benchmarked WER around 45-47% on real-world/noisy Persian speech (PSRB benchmark), i.e. not meaningfully better than what's here, with none of the Handy integration.

NVIDIA already publishes a FastConformer checkpoint for Persian (`nvidia/stt_fa_fastconformer_hybrid_large`, 115M, Common Voice fa-15.0 fine-tune of the English FastConformer encoder) that had never been converted for transcribe.cpp. It fills exactly this gap: same architecture family as Parakeet, so once converted it runs with the same CPU-only, instant-load, no-GPU-contention profile as Canary/Parakeet.

**Accuracy, honestly**: this is a Common Voice-only fine-tune, so — like most Common-Voice-trained models — it's strong on clean/formal audio and weaker on noisy or spontaneous speech. It is not a universal replacement for Whisper large-v3's accuracy ceiling on hard audio. It's the option for the (common) case where GPU contention/latency matters more than squeezing out the last few points of WER on noisy recordings — e.g. dictation in a normal room. In initial testing, in a quiet environment, it's been consistently accurate at Canary-like speed.

## What changed in the code

The checkpoint isn't in the known-slug list, and its architecture is a 'reverse hybrid': the primary decoder/joint is RNNT, and the CTC head we want to walk (`head_kind="ctc"`) lives under the auxiliary `ctc_decoder.` prefix instead of top-level `decoder.` — the opposite of `parakeet-tdt_ctc-*`, which drops `ctc_decoder.` the other way around. The existing CTC tensor-mapping table assumes the CTC decoder lives at `decoder.decoder_layers.0.*` (true only for the pure `parakeet-ctc-*` checkpoints, which have no RNNT head at all). Three changes to `convert-parakeet.py`, all additive:

1. **New `VARIANT_PROFILES` entry** (`stt-fa-fastconformer-hybrid-large`): registers the model's display name, size (115M), vocab_size (1024), license (cc-by-4.0, matching NVIDIA's original), and language (`fa`), following the exact same shape as the existing entries.

2. **New opt-in `ctc_from_aux` profile flag.** Right after `sd = model.state_dict()` loads, if this flag is set on the profile, the code aliases every `ctc_decoder.*` key onto a matching `decoder.*` key in the state dict:
```python
if profile.get("ctc_from_aux") and head_kind == "ctc":
    for k in list(sd.keys()):
        if k.startswith("ctc_decoder."):
            sd["decoder." + k[len("ctc_decoder."):]] = sd[k]
```
This makes the existing CTC tensor-mapping table's fixed `decoder.decoder_layers.0.*` lookups resolve to the right tensors, with zero changes to that table or to any other variant's conversion path — the flag defaults to unset/False everywhere else.

3. **Small extension to `is_expected_unused()`**: when `ctc_from_aux` is set, the now-genuinely-unused RNNT `decoder.prediction.*` / `joint.*` tensors, and the original (now aliased-away) `ctc_decoder.*` keys, are recognized as expected-unused instead of printing as spurious unconsumed-tensor warnings.

Net effect: **no existing variant's behavior changes** — every change is gated behind the new flag, which only this one profile sets.

## The converted model

Converts cleanly to a 417MB F32 GGUF (677 tensors). I've hosted it here so anyone can try it without running the conversion themselves:

https://huggingface.co/evilenor/stt-fa-fastconformer-hybrid-large-gguf

Loaded into Handy's local custom-models folder, it runs with the same CPU-only, instant-load profile as Canary/Parakeet.

**Request**: would you be open to adopting this hosted GGUF as the Persian option in Handy — either linking to it directly, or mirroring/re-uploading it under the `handy-computer` org so it's selectable from the in-app model list the same way Canary/Parakeet are? Happy to transfer it, rename it, add a quantized variant, or make any other changes needed to fit how the other models are packaged — let me know what you'd prefer.
