### PR TITLE
rust: support linking a prebuilt install via TRANSCRIBE_DIR

### DIFF
--- a/bindings/rust/sys/README.md
+++ b/bindings/rust/sys/README.md
@@ -61,6 +61,27 @@ $env:CARGO_TARGET_DIR = "C:\tc-target"
 cargo build --features vulkan
 ```
 
+## Linking a prebuilt install
+
+Set `TRANSCRIBE_DIR` (OPENSSL_DIR-style) to skip the source build and link an
+existing install prefix instead:
+
+```bash
+cmake -B build -DTRANSCRIBE_INSTALL=ON [-DTRANSCRIBE_BUILD_SHARED=ON ...]
+cmake --build build
+cmake --install build --prefix /opt/transcribe
+TRANSCRIBE_DIR=/opt/transcribe cargo build
+```
+
+The prefix must contain the installed `lib*/transcribe-link.json` manifest;
+the link line is reconstructed from it exactly as in a source build. Cargo
+features (`shared`, `vulkan`, ...) do not apply on this path — the prebuilt
+already fixed its configuration, and the manifest records it (including
+static vs shared). For a shared-library prefix, running consumer binaries
+may additionally need the prefix's lib dir on the loader path (e.g.
+`LD_LIBRARY_PATH=$TRANSCRIBE_DIR/lib`): the rpath the build emits does not
+propagate to downstream binaries.
+
 ## Build-flag escape hatch
 
 The features above cover the common, tested configurations. Anything else CMake

--- a/bindings/rust/sys/build.rs
+++ b/bindings/rust/sys/build.rs
@@ -1,11 +1,17 @@
 //! Build script for `transcribe-cpp-sys`.
 //!
-//! Source build is the primary (and currently only) path: the `cmake` crate
-//! drives the vendored C++ tree with `TRANSCRIBE_INSTALL=ON`, and the link
-//! line is reconstructed from NOTHING but the installed
-//! `lib/transcribe-link.json` manifest — the same artifact the `link_smoke`
-//! CI lane compiles a toy C consumer against. No per-platform link lists are
-//! hardcoded here (the whisper-rs drift class this avoids).
+//! Source build is the primary path: the `cmake` crate drives the vendored
+//! C++ tree with `TRANSCRIBE_INSTALL=ON`, and the link line is reconstructed
+//! from NOTHING but the installed `lib/transcribe-link.json` manifest — the
+//! same artifact the `link_smoke` CI lane compiles a toy C consumer against.
+//! No per-platform link lists are hardcoded here (the whisper-rs drift class
+//! this avoids).
+//!
+//! Prebuilt path: setting TRANSCRIBE_DIR (OPENSSL_DIR-style) to an install
+//! prefix produced by `cmake --install` of a TRANSCRIBE_INSTALL=ON build
+//! skips the source build entirely and links against that prefix's manifest
+//! instead. Cargo features are inert there: the prebuilt already decided its
+//! configuration (static/shared, backends), and the manifest records it.
 //!
 //! Cargo features map directly to CMake options:
 //!   `shared`           -> TRANSCRIBE_BUILD_SHARED=ON (default: static)
@@ -81,6 +87,29 @@ fn main() {
         "bindings/rust/sys/src",
     ] {
         println!("cargo:rerun-if-changed={}", root.join(p).display());
+    }
+
+    // Prebuilt path: TRANSCRIBE_DIR points at an existing install prefix (a
+    // `cmake --install` tree from a TRANSCRIBE_INSTALL=ON configure). Skip the
+    // source build and emit the link line from that prefix's manifest; the
+    // manifest records the install's own posture (static/shared, backends), so
+    // the Cargo features below never apply here.
+    println!("cargo:rerun-if-env-changed=TRANSCRIBE_DIR");
+    if let Some(dir) = env::var_os("TRANSCRIBE_DIR") {
+        let prefix = PathBuf::from(dir);
+        let manifest = find_manifest(&prefix).unwrap_or_else(|| {
+            panic!(
+                "TRANSCRIBE_DIR is set but no lib/transcribe-link.json (or lib64/) exists \
+                 under {}. It must point at an install prefix of this library, produced by \
+                 `cmake -B build -DTRANSCRIBE_INSTALL=ON && cmake --build build && \
+                 cmake --install build --prefix <dir>`. Unset TRANSCRIBE_DIR to build \
+                 the vendored sources instead.",
+                prefix.display()
+            )
+        });
+        println!("cargo:rerun-if-changed={}", manifest.display());
+        emit_link_lines(&prefix, &manifest);
+        return;
     }
 
     // `dynamic-backends` (loadable backend modules) requires a shared library,

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -39,7 +39,10 @@ binding's generated files:
   `GGML_BACKEND_DL` installs — `module_dir`, the directory to hand to
   `transcribe_init_backends()`. Proven per push by the link-smoke CI lane,
   which compiles a toy C consumer from nothing but this manifest in both
-  static and shared postures.
+  static and shared postures. The Rust `-sys` crate consumes it from two
+  sources: its own vendored source build (the default), or — with the
+  `TRANSCRIBE_DIR` env var pointing at an installed prefix — a prebuilt
+  tree, skipping the source build entirely.
 
 ## Result text pointers: copy at the FFI boundary
 


### PR DESCRIPTION

## Summary

Adds the system/prebuilt linking path requested in #97 to the Rust sys crate.
When `TRANSCRIBE_DIR` points to an install prefix (produced by `cmake --install`
of a `TRANSCRIBE_INSTALL=ON` build), the vendored cmake build is skipped and the
link line is emitted from that prefix's `lib*/transcribe-link.json` via the
existing `find_manifest`/`emit_link_lines` — no new link logic. Both static and
shared prefixes work. With `TRANSCRIBE_DIR` unset, behavior is unchanged
(insertion-only early return before the cmake step).

This is mainly for distro packaging: one system-wide libtranscribe package,
Rust consumers link against it instead of rebuilding ggml per project.

## AI Assistance

AI assisted with the implementation and docs; I reviewed, tested and own the
change.

## Validation

Built a shared install prefix, then built and tested a downstream consumer
against it with `TRANSCRIBE_DIR` — cmake is skipped, tests pass against the
linked library. A bogus `TRANSCRIBE_DIR` fails fast with a clear message.
