### PR TITLE
perf(gigaam): speed up inference by 3.7x

### DIFF
--- a/docs/tools/benchmarking.md
+++ b/docs/tools/benchmarking.md
@@ -94,6 +94,18 @@ per-cell delta table. Use `--name pre-refactor` / `--name post-refactor`
 for stable named baselines that overwrite on re-run, then compare the
 named pair.
 
+The comparison is also a correctness gate. Each matching cell must have the
+same UTF-8 transcript bytes and token IDs. An output mismatch causes a failed
+comparison. Use `--allow-output-change` only for an intentional output change.
+Review the output change separately from the performance change.
+
+```bash
+uv run scripts/bench/compare.py \
+  --baseline reports/perf/<machine>/pre-refactor_<variant>_<backend>.json \
+  --candidate reports/perf/<machine>/post-refactor_<variant>_<backend>.json \
+  --fail-on-missing
+```
+
 ## Quant coverage
 
 The default `--quants f16,q8_0,q4_k_m` covers the canonical tiers.

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1845,6 +1845,20 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d(ggml_met
     return res;
 }
 
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d_dw(ggml_metal_library_t lib, const ggml_tensor * op) {
+    assert(op->op == GGML_OP_CONV_2D_DW);
+    GGML_ASSERT(op->src[0]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->src[1]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->type == GGML_TYPE_F32);
+
+    const char * name = "kernel_conv_2d_dw_f32";
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, name, name, nullptr);
+    }
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_3d(ggml_metal_library_t lib, const ggml_tensor * op) {
     assert(op->op == GGML_OP_CONV_3D);
 

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -151,6 +151,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_im2col   
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_transpose_1d (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_transpose_2d (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d           (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d_dw        (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_3d           (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_upscale           (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_pad               (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1193,6 +1193,11 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                    op->src[1]->type == GGML_TYPE_F32 &&
                    op->type == GGML_TYPE_F32 &&
                    (op->src[0]->type == GGML_TYPE_F16 || op->src[0]->type == GGML_TYPE_F32);
+        case GGML_OP_CONV_2D_DW:
+            return ggml_is_contiguous(op->src[0]) &&
+                   op->src[0]->type == GGML_TYPE_F32 &&
+                   op->src[1]->type == GGML_TYPE_F32 &&
+                   op->type == GGML_TYPE_F32;
         case GGML_OP_UPSCALE:
             return op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_POOL_1D:

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -387,6 +387,10 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
             {
                 n_fuse = ggml_metal_op_conv_2d(ctx, idx);
             } break;
+        case GGML_OP_CONV_2D_DW:
+            {
+                n_fuse = ggml_metal_op_conv_2d_dw(ctx, idx);
+            } break;
         case GGML_OP_CONV_TRANSPOSE_1D:
             {
                 n_fuse = ggml_metal_op_conv_transpose_1d(ctx, idx);
@@ -3735,6 +3739,48 @@ int ggml_metal_op_conv_2d(ggml_metal_op_t ctx, int idx) {
 
     ggml_metal_encoder_dispatch_threadgroups(enc, tg, 1, 1, nth, 1, 1);
 
+    return 1;
+}
+
+int ggml_metal_op_conv_2d_dw(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
+    GGML_TENSOR_LOCALS(uint64_t, nb0, op->src[0], nb);
+    GGML_TENSOR_LOCALS( int32_t, ne1, op->src[1], ne);
+    GGML_TENSOR_LOCALS(uint64_t, nb1, op->src[1], nb);
+    GGML_TENSOR_LOCALS( int32_t, ne,  op,         ne);
+    GGML_TENSOR_LOCALS(uint64_t, nb,  op,         nb);
+
+    GGML_ASSERT(ggml_is_contiguous(op->src[0]));
+    GGML_ASSERT(op->src[0]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->src[1]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->type == GGML_TYPE_F32);
+
+    ggml_metal_kargs_conv_2d args = {
+        nb00, nb01, nb02, nb03,
+        nb10, nb11, nb12, nb13,
+        nb0, nb1, nb2, nb3,
+        ne10, ne11, ne00, ne01, ne12, ne12, ne0, ne1, ne3,
+        ((const int32_t *) op->op_params)[0],
+        ((const int32_t *) op->op_params)[1],
+        ((const int32_t *) op->op_params)[2],
+        ((const int32_t *) op->op_params)[3],
+        ((const int32_t *) op->op_params)[4],
+        ((const int32_t *) op->op_params)[5],
+    };
+
+    auto pipeline = ggml_metal_library_get_pipeline_conv_2d_dw(ctx->lib, op);
+    int nth = std::clamp(ggml_metal_pipeline_max_theads_per_threadgroup(pipeline), 1, 256);
+    const uint64_t n_out = ggml_nelements(op);
+    const uint64_t tg = std::max<uint64_t>(1, (n_out + nth - 1)/nth);
+
+    ggml_metal_encoder_set_pipeline(ctx->enc, pipeline);
+    ggml_metal_encoder_set_bytes   (ctx->enc, &args, sizeof(args), 0);
+    ggml_metal_encoder_set_buffer  (ctx->enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+    ggml_metal_encoder_set_buffer  (ctx->enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+    ggml_metal_encoder_set_buffer  (ctx->enc, ggml_metal_get_buffer_id(op),         3);
+    ggml_metal_encoder_dispatch_threadgroups(ctx->enc, tg, 1, 1, nth, 1, 1);
     return 1;
 }
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.h
+++ b/ggml/src/ggml-metal/ggml-metal-ops.h
@@ -75,6 +75,7 @@ int ggml_metal_op_norm              (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_rope              (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_im2col            (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_conv_2d           (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_conv_2d_dw        (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_conv_3d           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_conv_transpose_1d (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_conv_transpose_2d (ggml_metal_op_t ctx, int idx);

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -4906,6 +4906,47 @@ kernel void kernel_conv_2d<half>(
         uint3   tpitg[[thread_position_in_threadgroup]],
         uint3     ntg[[threads_per_threadgroup]]);
 
+kernel void kernel_conv_2d_dw_f32(
+        constant ggml_metal_kargs_conv_2d & args,
+        device const char * weights,
+        device const char * src,
+        device       char * dst,
+        uint gid [[thread_position_in_grid]]) {
+    // One thread computes one [ow, oh, channel, batch] output. Depthwise
+    // convolution reads only the matching channel from input and weights.
+    const uint64_t total = (uint64_t) args.N * args.IC * args.OH * args.OW;
+    if (gid >= total) {
+        return;
+    }
+
+    uint64_t index = gid;
+    const int32_t ow = index % args.OW; index /= args.OW;
+    const int32_t oh = index % args.OH; index /= args.OH;
+    const int32_t  c = index % args.IC; index /= args.IC;
+    const int32_t  n = index;
+    const int32_t base_x = ow * args.s0 - args.p0;
+    const int32_t base_y = oh * args.s1 - args.p1;
+
+    float acc = 0.0f;
+    for (int32_t ky = 0; ky < args.KH; ++ky) {
+        const int32_t iy = base_y + ky * args.d1;
+        if (iy < 0 || iy >= args.IH) {
+            continue;
+        }
+        for (int32_t kx = 0; kx < args.KW; ++kx) {
+            const int32_t ix = base_x + kx * args.d0;
+            if (ix < 0 || ix >= args.IW) {
+                continue;
+            }
+            const uint64_t woff = (uint64_t) kx * args.nb00 + (uint64_t) ky * args.nb01 + (uint64_t) c * args.nb03;
+            const uint64_t xoff = (uint64_t) ix * args.nb10 + (uint64_t) iy * args.nb11 + (uint64_t) c * args.nb12 + (uint64_t) n * args.nb13;
+            acc += *(device const float *)(src + xoff) * *(device const float *)(weights + woff);
+        }
+    }
+    const uint64_t doff = (uint64_t) ow * args.nb0 + (uint64_t) oh * args.nb1 + (uint64_t) c * args.nb2 + (uint64_t) n * args.nb3;
+    *(device float *)(dst + doff) = acc;
+}
+
 typedef void (conv_transpose_1d_t)(
         constant ggml_metal_kargs_conv_transpose_1d & args,
         device const float * src0,

--- a/scripts/bench/compare.py
+++ b/scripts/bench/compare.py
@@ -40,6 +40,8 @@ Options:
                         (default: disabled). Only wall_ms regressions count.
     --fail-on-missing   fail (exit 1) if any cell is in baseline but not in
                         candidate, or vice versa.
+    --allow-output-change
+                        allow transcript/token changes (default: fail)
     --key FIELD         timing field to compare (default: wall_ms)
     --quiet             only print regressions and new/gone cells
 """
@@ -47,6 +49,7 @@ Options:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from dataclasses import dataclass
@@ -78,6 +81,19 @@ class RunValue:
     total_ms: float
     mel_ms: float
     rtf: float
+    transcript_sha256: str
+    token_ids_sha256: str
+
+
+def _sha256_utf8(value: object) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest() if isinstance(value, str) else ""
+
+
+def output_fingerprints(run: dict) -> tuple[str, str]:
+    """Return the transcript and token ID fingerprints for one run."""
+    transcript = run.get("transcript_sha256") or _sha256_utf8(run.get("hyp_text"))
+    token_ids = run.get("token_ids_sha256") or _sha256_utf8(run.get("token_ids_csv"))
+    return str(transcript), str(token_ids)
 
 
 def parse_quant_from_path(model_path: str) -> str:
@@ -130,6 +146,7 @@ def load_report(path: Path) -> tuple[str, str, dict[RunKey, RunValue]]:
             rtf = r.get("rtf_wall_mean") or r.get("rtf_mean") or 0.0
             key = RunKey(variant=variant, backend=backend, quant=quant,
                          sample=sample)
+            transcript_sha256, token_ids_sha256 = output_fingerprints(r)
             runs[key] = RunValue(
                 wall_ms=extract_mean(summary, "wall_ms"),
                 encode_ms=extract_mean(summary, "encode_ms"),
@@ -137,6 +154,8 @@ def load_report(path: Path) -> tuple[str, str, dict[RunKey, RunValue]]:
                 total_ms=extract_mean(summary, "total_ms"),
                 mel_ms=extract_mean(summary, "mel_ms"),
                 rtf=float(rtf),
+                transcript_sha256=transcript_sha256,
+                token_ids_sha256=token_ids_sha256,
             )
 
     elif schema in ("transcribe-bench-v1", "transcribe-bench-v2"):
@@ -152,6 +171,7 @@ def load_report(path: Path) -> tuple[str, str, dict[RunKey, RunValue]]:
         rtf = data.get("rtf_wall_mean") or data.get("rtf_mean") or 0.0
         key = RunKey(variant=variant, backend=backend, quant=quant,
                      sample=sample)
+        transcript_sha256, token_ids_sha256 = output_fingerprints(data)
         runs[key] = RunValue(
             wall_ms=extract_mean(summary, "wall_ms"),
             encode_ms=extract_mean(summary, "encode_ms"),
@@ -159,6 +179,8 @@ def load_report(path: Path) -> tuple[str, str, dict[RunKey, RunValue]]:
             total_ms=extract_mean(summary, "total_ms"),
             mel_ms=extract_mean(summary, "mel_ms"),
             rtf=float(rtf),
+            transcript_sha256=transcript_sha256,
+            token_ids_sha256=token_ids_sha256,
         )
 
     else:
@@ -210,6 +232,9 @@ def main() -> int:
     p.add_argument("--fail-on-missing", action="store_true",
                    help="Fail if any cell is present on one side but not "
                         "the other (new or gone)")
+    p.add_argument("--allow-output-change", action="store_true",
+                   help="Do not fail when transcript or token IDs differ. "
+                        "By default output identity is a mandatory gate.")
     p.add_argument("--key", type=str, default="wall_ms",
                    choices=["wall_ms", "total_ms", "encode_ms", "decode_ms",
                             "mel_ms"],
@@ -248,6 +273,7 @@ def main() -> int:
     rows: list[tuple[str, ...]] = []
     regressions: list[tuple[RunKey, float]] = []
     missing_cells: list[tuple[RunKey, str]] = []  # (key, "new" | "gone")
+    output_failures: list[tuple[RunKey, str]] = []
 
     for key in all_keys:
         bv = base_runs.get(key)
@@ -271,9 +297,25 @@ def main() -> int:
         else:
             delta_pct = 0.0
 
+        changed = []
+        unverified = []
+        for name in ("transcript_sha256", "token_ids_sha256"):
+            base_fingerprint = getattr(bv, name)
+            candidate_fingerprint = getattr(cv, name)
+            if not base_fingerprint or not candidate_fingerprint:
+                unverified.append(name.removesuffix("_sha256"))
+            elif base_fingerprint != candidate_fingerprint:
+                changed.append(name.removesuffix("_sha256"))
+
         # Positive delta = regression (slower), negative = improvement.
         status = "ok"
-        if args.threshold is not None and delta_pct > args.threshold:
+        if changed:
+            status = "OUTPUT_CHANGED"
+            output_failures.append((key, ", ".join(changed)))
+        elif unverified:
+            status = "OUTPUT_UNVERIFIED"
+            output_failures.append((key, ", ".join(unverified)))
+        elif args.threshold is not None and delta_pct > args.threshold:
             status = "REGRESSED"
             regressions.append((key, delta_pct))
 
@@ -301,7 +343,7 @@ def main() -> int:
         print("  " + "-" * (sum(widths) + 3 * (len(widths) - 1)))
 
     for row in rows:
-        is_notable = row[7] in ("REGRESSED", "new", "gone")
+        is_notable = row[7] in ("REGRESSED", "OUTPUT_CHANGED", "OUTPUT_UNVERIFIED", "new", "gone")
         if args.quiet and not is_notable:
             continue
         print(fmt_row(row))
@@ -331,11 +373,19 @@ def main() -> int:
         if args.fail_on_missing:
             exit_code = 1
 
+    if output_failures:
+        print(f"\n{len(output_failures)} output identity failure(s):")
+        for key, fields in output_failures:
+            print(f"  {key.variant}/{key.backend}/{key.quant}/{key.sample}: {fields}")
+        if not args.allow_output_change:
+            exit_code = 1
+
     if exit_code == 0:
         detail = ""
         if args.threshold is not None:
             detail += f" (threshold {args.threshold:.1f}%)"
-        print(f"\n{n_cells} cell(s) compared, no regressions{detail}")
+        output_status = "output changes allowed" if output_failures else "outputs identical"
+        print(f"\n{n_cells} cell(s) compared, {output_status}, no regressions{detail}")
 
     return exit_code
 

--- a/scripts/bench/test_compare.py
+++ b/scripts/bench/test_compare.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("compare.py")
+SPEC = importlib.util.spec_from_file_location("bench_compare", SCRIPT)
+assert SPEC and SPEC.loader
+bench_compare = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = bench_compare
+SPEC.loader.exec_module(bench_compare)
+
+
+def report(text: str, token_ids: str) -> dict:
+    return {
+        "schema": "transcribe-bench-driver-v1",
+        "name": "test",
+        "git_sha": "deadbee",
+        "variant": "gigaam-v3-e2e-rnnt",
+        "backend": "metal",
+        "runs": [{
+            "model_path": "models/gigaam-v3-e2e-rnnt-Q4_K_M.gguf",
+            "sample_path": "samples/ru.wav",
+            "hyp_text": text,
+            "token_ids_csv": token_ids,
+            "summary": {"wall_ms": {"mean": 100.0}},
+        }],
+    }
+
+
+class CompareOutputIdentityTest(unittest.TestCase):
+    def run_compare(self, baseline: dict, candidate: dict, *extra: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            baseline_path = root / "baseline.json"
+            candidate_path = root / "candidate.json"
+            baseline_path.write_text(json.dumps(baseline))
+            candidate_path.write_text(json.dumps(candidate))
+            return subprocess.run(
+                [sys.executable, str(SCRIPT), "--baseline", str(baseline_path),
+                 "--candidate", str(candidate_path), *extra],
+                text=True, capture_output=True, check=False,
+            )
+
+    def test_identical_utf8_outputs_pass(self) -> None:
+        result = self.run_compare(report("Привет, мир?", "1,2,3"), report("Привет, мир?", "1,2,3"))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("outputs identical", result.stdout)
+
+    def test_transcript_byte_change_fails(self) -> None:
+        result = self.run_compare(report("Привет, мир?", "1,2,3"), report("привет мир", "1,2,3"))
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("OUTPUT_CHANGED", result.stdout)
+        self.assertIn("transcript", result.stdout)
+
+    def test_token_change_fails_even_when_text_matches(self) -> None:
+        result = self.run_compare(report("same", "1,2,3"), report("same", "1,9,3"))
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("token_ids", result.stdout)
+
+    def test_output_change_can_be_explicitly_allowed(self) -> None:
+        result = self.run_compare(report("before", "1"), report("after", "2"), "--allow-output-change")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/arch/gigaam/decoder.cpp
+++ b/src/arch/gigaam/decoder.cpp
@@ -74,6 +74,14 @@ inline float sigmoidf(float x) {
 // y = W @ x + b, where W is [out, in] row-major (numpy shape), x is
 // [in], b is [out]. b may be nullptr to skip the add.
 void matvec_add(const float * W, const float * b, const float * x, int out, int in_dim, float * y) {
+#if TRANSCRIBE_HAS_BLAS
+    if (b != nullptr) {
+        std::memcpy(y, b, static_cast<size_t>(out) * sizeof(float));
+    } else {
+        std::fill(y, y + out, 0.0f);
+    }
+    cblas_sgemv(CblasRowMajor, CblasNoTrans, out, in_dim, 1.0f, W, in_dim, x, 1, 1.0f, y, 1);
+#else
     for (int i = 0; i < out; ++i) {
         float         acc = (b != nullptr) ? b[i] : 0.0f;
         const float * row = W + static_cast<size_t>(i) * in_dim;
@@ -82,6 +90,7 @@ void matvec_add(const float * W, const float * b, const float * x, int out, int 
         }
         y[i] = acc;
     }
+#endif
 }
 
 }  // namespace
@@ -136,6 +145,11 @@ static void lstm_step(const float * x,
                       float *       c_out,
                       float *       scratch_gates) {
     // scratch_gates: [4*H]. Compute Wx @ x + Wh @ h_prev + b in place.
+#if TRANSCRIBE_HAS_BLAS
+    std::memcpy(scratch_gates, b, static_cast<size_t>(4 * H) * sizeof(float));
+    cblas_sgemv(CblasRowMajor, CblasNoTrans, 4 * H, H, 1.0f, Wx, H, x, 1, 1.0f, scratch_gates, 1);
+    cblas_sgemv(CblasRowMajor, CblasNoTrans, 4 * H, H, 1.0f, Wh, H, h_prev, 1, 1.0f, scratch_gates, 1);
+#else
     for (int i = 0; i < 4 * H; ++i) {
         float         acc    = b[i];
         const float * wx_row = Wx + static_cast<size_t>(i) * H;
@@ -145,6 +159,7 @@ static void lstm_step(const float * x,
         }
         scratch_gates[i] = acc;
     }
+#endif
 
     const float * gi = scratch_gates;
     const float * gf = scratch_gates + H;
@@ -202,6 +217,61 @@ static int joint_argmax(const HostDecoderWeights & h,
     return best_idx;
 }
 
+// Evaluate multiple encoder frames for one predictor state.
+// `out_tokens[t]` contains the greedy token for frame `t`.
+// One BLAS operation calculates the output projection for all frames.
+// One matrix-vector operation calculates the predictor projection.
+static void joint_argmax_span(const HostDecoderWeights & h,
+                              const float *              enc_proj,
+                              const float *              g_t,
+                              int                        n_frames,
+                              int                        pred_d,
+                              int                        joint_h,
+                              int                        n_classes,
+                              std::vector<float> &       pred_proj,
+                              std::vector<float> &       join,
+                              std::vector<float> &       logits,
+                              std::vector<int> &         out_tokens) {
+    pred_proj.assign(joint_h, 0.0f);
+    join.resize(static_cast<size_t>(n_frames) * joint_h);
+    logits.resize(static_cast<size_t>(n_frames) * n_classes);
+    out_tokens.resize(n_frames);
+
+    matvec_add(h.joint_pred_w.data(), h.joint_pred_b.data(), g_t, joint_h, pred_d, pred_proj.data());
+    for (int t = 0; t < n_frames; ++t) {
+        const float * enc_row  = enc_proj + static_cast<size_t>(t) * joint_h;
+        float *       join_row = join.data() + static_cast<size_t>(t) * joint_h;
+        for (int j = 0; j < joint_h; ++j) {
+            const float value = enc_row[j] + pred_proj[j];
+            join_row[j]       = value > 0.0f ? value : 0.0f;
+        }
+    }
+
+#if TRANSCRIBE_HAS_BLAS
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, n_frames, n_classes, joint_h, 1.0f, join.data(), joint_h,
+                h.joint_out_w.data(), joint_h, 0.0f, logits.data(), n_classes);
+#else
+    for (int t = 0; t < n_frames; ++t) {
+        matvec_add(h.joint_out_w.data(), nullptr, join.data() + static_cast<size_t>(t) * joint_h, n_classes, joint_h,
+                   logits.data() + static_cast<size_t>(t) * n_classes);
+    }
+#endif
+
+    for (int t = 0; t < n_frames; ++t) {
+        float * row      = logits.data() + static_cast<size_t>(t) * n_classes;
+        int     best_idx = 0;
+        float   best_val = row[0] + h.joint_out_b[0];
+        for (int i = 1; i < n_classes; ++i) {
+            const float value = row[i] + h.joint_out_b[i];
+            if (value > best_val) {
+                best_val = value;
+                best_idx = i;
+            }
+        }
+        out_tokens[t] = best_idx;
+    }
+}
+
 // Run RNN-T greedy decode against the encoder output. `encoded` is a
 // host-side buffer laid out [T_enc * d_model] in T-major order (each
 // contiguous d_model-sized chunk is one time step's encoder vector) —
@@ -255,6 +325,10 @@ transcribe_status decode_rnnt_greedy(const HostDecoderWeights & host,
     std::vector<float> pred_in(H, 0.0f);  // embed lookup output
     std::vector<float> jh(joint_h, 0.0f);
     std::vector<float> logits(n_class, 0.0f);
+    std::vector<float> span_pred_proj;
+    std::vector<float> span_join;
+    std::vector<float> span_logits;
+    std::vector<int>   span_tokens;
 
     bool fresh = true;  // first step uses zero input + zero state (reference predict(None, None))
 
@@ -265,42 +339,66 @@ transcribe_status decode_rnnt_greedy(const HostDecoderWeights & host,
     // unconditional path.
     bool predictor_dirty = true;
 
-    for (int t = 0; t < T_enc; ++t) {
-        const float * enc_proj = enc_proj_all.data() + static_cast<size_t>(t) * joint_h;
-
-        int sym_count = 0;
-        for (;;) {
-            if (predictor_dirty) {
-                if (fresh) {
-                    std::fill(pred_in.begin(), pred_in.end(), 0.0f);
-                } else {
-                    const int prev = out_tokens.back();
-                    std::memcpy(pred_in.data(), host.pred_embed.data() + static_cast<size_t>(prev) * H,
-                                H * sizeof(float));
-                }
-                lstm_step(pred_in.data(), h_cur.data(), c_cur.data(), host.lstm_Wx[0].data(), host.lstm_Wh[0].data(),
-                          host.lstm_b[0].data(), H, h_next.data(), c_next.data(), gates.data());
-                predictor_dirty = false;
+    constexpr int lookahead = 32;
+    int           t         = 0;
+    while (t < T_enc) {
+        if (predictor_dirty) {
+            if (fresh) {
+                std::fill(pred_in.begin(), pred_in.end(), 0.0f);
+            } else {
+                const int prev = out_tokens.back();
+                std::memcpy(pred_in.data(), host.pred_embed.data() + static_cast<size_t>(prev) * H, H * sizeof(float));
             }
+            lstm_step(pred_in.data(), h_cur.data(), c_cur.data(), host.lstm_Wx[0].data(), host.lstm_Wh[0].data(),
+                      host.lstm_b[0].data(), H, h_next.data(), c_next.data(), gates.data());
+            predictor_dirty = false;
+        }
 
-            const int tok = joint_argmax(host, enc_proj, h_next.data(), H, joint_h, n_class, jh, logits);
+        const int span = std::min(lookahead, T_enc - t);
+        joint_argmax_span(host, enc_proj_all.data() + static_cast<size_t>(t) * joint_h, h_next.data(), span, H, joint_h,
+                          n_class, span_pred_proj, span_join, span_logits, span_tokens);
 
+        int offset = 0;
+        while (offset < span && span_tokens[offset] == blank_id) {
+            ++offset;
+        }
+        if (offset == span) {
+            t += span;
+            continue;
+        }
+
+        t += offset;
+        int tok = span_tokens[offset];
+        out_tokens.push_back(tok);
+        out_frames.push_back(t);
+        h_cur           = h_next;
+        c_cur           = c_next;
+        fresh           = false;
+        predictor_dirty = true;
+
+        int sym_count = 1;
+        while (max_symbols_per_step <= 0 || sym_count < max_symbols_per_step) {
+            const int prev = out_tokens.back();
+            std::memcpy(pred_in.data(), host.pred_embed.data() + static_cast<size_t>(prev) * H, H * sizeof(float));
+            lstm_step(pred_in.data(), h_cur.data(), c_cur.data(), host.lstm_Wx[0].data(), host.lstm_Wh[0].data(),
+                      host.lstm_b[0].data(), H, h_next.data(), c_next.data(), gates.data());
+            predictor_dirty     = false;
+            const float * enc_p = enc_proj_all.data() + static_cast<size_t>(t) * joint_h;
+            tok                 = joint_argmax(host, enc_p, h_next.data(), H, joint_h, n_class, jh, logits);
             if (tok == blank_id) {
-                // Advance time. Do NOT commit state. Predictor stays clean.
+                // A blank advances time without committing the candidate
+                // predictor state. The next frame can reuse h_next.
                 break;
             }
-            // Emit token; commit state.
+            // A token commits the candidate state and invalidates the cache.
             out_tokens.push_back(tok);
             out_frames.push_back(t);
             h_cur           = h_next;
             c_cur           = c_next;
-            fresh           = false;
             predictor_dirty = true;
             ++sym_count;
-            if (max_symbols_per_step > 0 && sym_count >= max_symbols_per_step) {
-                break;
-            }
         }
+        ++t;
     }
 
     return TRANSCRIBE_OK;

--- a/src/arch/gigaam/encoder.cpp
+++ b/src/arch/gigaam/encoder.cpp
@@ -188,9 +188,7 @@ ggml_tensor * build_rotary_attn(ggml_context *      ctx,
     ggml_tensor * o;
     if (flash) {
         o = ggml_flash_attn_ext(ctx, q, k, v, /*mask=*/nullptr, scale, 0.0f, 0.0f);
-        // ggml_flash_attn_ext returns [head_dim, n_head, T, B].
-        o = ggml_permute(ctx, o, 0, 2, 1, 3);
-        o = ggml_cont(ctx, o);
+        // Flash attention returns contiguous [head_dim, n_head, T, B] data.
     } else {
         ggml_tensor * kq = ggml_mul_mat(ctx, k, q);  // [T_k, T_q, n_head, B]
         // Additive key-padding mask: ne=[T_k, 1, 1, B] broadcasts over
@@ -202,10 +200,10 @@ ggml_tensor * build_rotary_attn(ggml_context *      ctx,
         ggml_tensor * kq_soft = ggml_soft_max_ext(ctx, kq, /*mask=*/nullptr, scale, 0.0f);
         ggml_tensor * v_t     = ggml_cont(ctx, ggml_permute(ctx, v, 1, 0, 2, 3));
         o                     = ggml_mul_mat(ctx, v_t, kq_soft);
+        // Manual attention returns [head_dim, T, n_head, B] data.
+        o = ggml_cont(ctx, ggml_permute(ctx, o, 0, 2, 1, 3));
     }
-    // o: [head_dim, T, n_head, B] -> [head_dim, n_head, T, B] -> [d_model, T, B]
-    o = ggml_permute(ctx, o, 0, 2, 1, 3);
-    o = ggml_cont(ctx, o);
+    // Both paths now return contiguous [head_dim, n_head, T, B] data.
     o = ggml_reshape_3d(ctx, o, d_model, T, Bb);
 
     // Output projection.

--- a/src/arch/gigaam/mel.cpp
+++ b/src/arch/gigaam/mel.cpp
@@ -11,10 +11,19 @@
 #include "ggml.h"
 #include "weights.h"
 
+#if TRANSCRIBE_HAS_BLAS
+#    ifdef __APPLE__
+#        include <Accelerate/Accelerate.h>
+#    else
+#        include <cblas.h>
+#    endif
+#endif
+
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <thread>
 
 namespace transcribe::gigaam {
 
@@ -126,49 +135,64 @@ transcribe_status GigaamMelFrontend::compute(const float *        pcm,
 
     out_mel.assign(static_cast<size_t>(n_mels) * n_frames, 0.0f);
 
-    // Scratch buffers for the FFT. Reused across frames.
-    std::vector<float> fft_in(2 * n_fft);
-    std::vector<float> fft_out(8 * n_fft);
-    std::vector<float> power_spec(n_freq);
+    // Each frame has an independent FFT.
+    // Store the power spectra in [n_frames, n_freq] layout.
+    // One BLAS operation calculates the mel projection for all frames.
+    std::vector<float> power(static_cast<size_t>(n_frames) * n_freq);
+    const unsigned int available = std::max(1u, std::thread::hardware_concurrency());
+    const int          n_workers = std::min(n_frames, static_cast<int>(available));
+    auto               worker    = [&](int worker_id) {
+        std::vector<float> fft_in(2 * n_fft);
+        std::vector<float> fft_out(8 * n_fft);
+        for (int t = worker_id; t < n_frames; t += n_workers) {
+            const size_t start = static_cast<size_t>(t) * hop_length;
+            // GigaAM normally has n_fft == win_length. Keep the tail zeroed
+            // so a model with a larger FFT still gets correct zero-padding.
+            std::fill(fft_in.begin(), fft_in.begin() + n_fft, 0.0f);
+            for (int k = 0; k < win_length; ++k) {
+                fft_in[k] = pcm[start + k] * hann[k];
+            }
+            mixed_radix_fft(fft_in.data(), n_fft, fft_out.data());
 
-    for (int t = 0; t < n_frames; ++t) {
-        const size_t start = static_cast<size_t>(t) * hop_length;
-        // Window the frame: x[start..start+win_length) * hann.
-        // n_fft == win_length for gigaam, so the FFT input is exactly
-        // the windowed frame (no zero-pad needed). The pre-zeroed
-        // scratch space ahead of the FFT_in[win_length..n_fft) covers
-        // the unlikely n_fft > win_length case for completeness.
-        std::fill(fft_in.begin(), fft_in.begin() + n_fft, 0.0f);
-        for (int k = 0; k < win_length; ++k) {
-            fft_in[k] = pcm[start + k] * hann[k];
-        }
-        mixed_radix_fft(fft_in.data(), n_fft, fft_out.data());
-
-        // power_spec[k] = |X[k]|^2 (power=2).
-        for (int k = 0; k < n_freq; ++k) {
-            const float re = fft_out[2 * k];
-            const float im = fft_out[2 * k + 1];
-            power_spec[k]  = re * re + im * im;
-        }
-
-        // mel[m] = sum_k filterbank[m, k] * power_spec[k]; then
-        // log(clamp(x, 1e-9, 1e9)).
-        for (int m = 0; m < n_mels; ++m) {
-            const float * row = mel_fb.data() + static_cast<size_t>(m) * n_freq;
-            float         acc = 0.0f;
+            float * power_row = power.data() + static_cast<size_t>(t) * n_freq;
             for (int k = 0; k < n_freq; ++k) {
-                acc += row[k] * power_spec[k];
+                const float re = fft_out[2 * k];
+                const float im = fft_out[2 * k + 1];
+                power_row[k]   = re * re + im * im;
             }
-            if (acc < 1.0e-9f) {
-                acc = 1.0e-9f;
-            }
-            // The upper clamp at 1e9 in the reference is unreachable for
-            // realistic 16-bit PCM, but mirror it for byte-equivalence.
-            if (acc > 1.0e9f) {
-                acc = 1.0e9f;
-            }
-            out_mel[static_cast<size_t>(m) * n_frames + t] = std::log(acc);
         }
+    };
+    std::vector<std::thread> workers;
+    workers.reserve(n_workers > 0 ? static_cast<size_t>(n_workers - 1) : 0);
+    for (int worker_id = 1; worker_id < n_workers; ++worker_id) {
+        workers.emplace_back(worker, worker_id);
+    }
+    worker(0);
+    for (auto & thread : workers) {
+        thread.join();
+    }
+
+#if TRANSCRIBE_HAS_BLAS
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, n_mels, n_frames, n_freq, 1.0f, mel_fb.data(), n_freq,
+                power.data(), n_freq, 0.0f, out_mel.data(), n_frames);
+#else
+    for (int m = 0; m < n_mels; ++m) {
+        const float * filter = mel_fb.data() + static_cast<size_t>(m) * n_freq;
+        for (int t = 0; t < n_frames; ++t) {
+            const float * power_row = power.data() + static_cast<size_t>(t) * n_freq;
+            float         acc       = 0.0f;
+            for (int k = 0; k < n_freq; ++k) {
+                acc += filter[k] * power_row[k];
+            }
+            out_mel[static_cast<size_t>(m) * n_frames + t] = acc;
+        }
+    }
+#endif
+
+    // Match the reference clamp on both ends. The upper limit is not
+    // expected for normalized PCM, but keeping it preserves exact behavior.
+    for (float & value : out_mel) {
+        value = std::log(std::clamp(value, 1.0e-9f, 1.0e9f));
     }
     return TRANSCRIBE_OK;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,15 @@ transcribe_apply_warnings(transcribe_backend_init_unit)
 add_test(NAME transcribe_backend_init_unit
     COMMAND transcribe_backend_init_unit)
 
+if(TRANSCRIBE_METAL)
+    add_executable(transcribe_metal_conv_2d_dw_unit metal_conv_2d_dw_unit.cpp)
+    target_link_libraries(transcribe_metal_conv_2d_dw_unit PRIVATE transcribe ggml)
+    target_include_directories(transcribe_metal_conv_2d_dw_unit PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    transcribe_apply_warnings(transcribe_metal_conv_2d_dw_unit)
+    add_test(NAME transcribe_metal_conv_2d_dw_unit COMMAND transcribe_metal_conv_2d_dw_unit)
+    set_tests_properties(transcribe_metal_conv_2d_dw_unit PROPERTIES SKIP_RETURN_CODE 77)
+endif()
+
 # -----------------------------------------------------------------------------
 # Parakeet chunked_limited_with_rc attention mask unit test
 # -----------------------------------------------------------------------------

--- a/tests/metal_conv_2d_dw_unit.cpp
+++ b/tests/metal_conv_2d_dw_unit.cpp
@@ -1,0 +1,94 @@
+#include "ggml-backend.h"
+#include "ggml.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+ggml_backend_t backend_by_type(enum ggml_backend_dev_type type) {
+    for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        if (ggml_backend_dev_type(dev) == type) {
+            if (ggml_backend_t backend = ggml_backend_dev_init(dev, nullptr)) {
+                return backend;
+            }
+        }
+    }
+    return nullptr;
+}
+
+ggml_backend_t metal_backend() {
+    for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        if (std::strncmp(ggml_backend_dev_name(dev), "MTL", 3) == 0) {
+            return ggml_backend_dev_init(dev, nullptr);
+        }
+    }
+    return nullptr;
+}
+
+std::vector<float> run_depthwise(ggml_backend_t backend) {
+    ggml_init_params params{};
+    params.mem_size    = 1024 * 1024;
+    params.no_alloc    = true;
+    ggml_context * ctx = ggml_init(params);
+
+    ggml_tensor * weights = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, 3, 1, 1, 2);
+    ggml_tensor * input   = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, 7, 1, 2, 2);
+    ggml_tensor * output  = ggml_conv_2d_dw_direct(ctx, weights, input, 1, 1, 1, 0, 1, 1);
+    ggml_cgraph * graph   = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, output);
+
+    ggml_backend_buffer_t    buffer      = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    const std::vector<float> weight_data = { 0.25f, -0.5f, 0.75f, -1.0f, 0.125f, 0.5f };
+    const std::vector<float> input_data  = {
+        1, 2, 3, 4, 5, 6, 7, -1, 0.5f, 2, -3, 4, -5, 6, 7, 6, 5, 4, 3, 2, 1, 3, -2, 1, 0, -1, 2, -3,
+    };
+    ggml_backend_tensor_set(weights, weight_data.data(), 0, weight_data.size() * sizeof(float));
+    ggml_backend_tensor_set(input, input_data.data(), 0, input_data.size() * sizeof(float));
+    if (ggml_backend_graph_compute(backend, graph) != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "depthwise graph compute failed\n");
+        std::abort();
+    }
+
+    std::vector<float> result(ggml_nelements(output));
+    ggml_backend_tensor_get(output, result.data(), 0, result.size() * sizeof(float));
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    return result;
+}
+
+}  // namespace
+
+int main() {
+    ggml_backend_load_all();
+    ggml_backend_t metal = metal_backend();
+    if (metal == nullptr) {
+        std::fprintf(stderr, "SKIP: Metal backend unavailable\n");
+        return 77;
+    }
+    ggml_backend_t cpu = backend_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    if (cpu == nullptr) {
+        ggml_backend_free(metal);
+        return EXIT_FAILURE;
+    }
+
+    const std::vector<float> expected = run_depthwise(cpu);
+    const std::vector<float> actual   = run_depthwise(metal);
+    ggml_backend_free(cpu);
+    ggml_backend_free(metal);
+
+    if (actual.size() != expected.size()) {
+        return EXIT_FAILURE;
+    }
+    const size_t result_bytes = actual.size() * sizeof(float);
+    if (std::memcmp(actual.data(), expected.data(), result_bytes) != 0) {
+        std::fprintf(stderr, "Metal output is not byte-identical to CPU output\n");
+        return EXIT_FAILURE;
+    }
+    std::fprintf(stdout, "metal_conv_2d_dw_unit: %zu values are byte-identical\n", actual.size());
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Speed up GigaAM inference while keeping the same transcripts and token IDs.

Measured on Apple M1 Max with Metal and the E2E RNNT Q8_0 model. Each result is the median of three paired AB/BA rounds over `ru.wav`, `jfk.wav`, and `dots.wav`.

| Commit | Change | Incremental speedup | Cumulative speedup |
|---|---|---:|---:|
| `0e04064` | Add output identity checks | 1.00× | 1.00× |
| `e9f4784` | Batch and reuse host decoder work | 2.11× | 2.11× |
| `dbf1b57` | Parallelize mel and remove attention copies | 1.42× | 3.06× |
| `85c1844` | Run depthwise convolution on Metal | 1.18× | **3.70×** |

| Transition | Main stage improvement | End-to-end improvement |
|---|---:|---:|
| Baseline → host decoder | Decoder: 6.92× | 2.12× |
| Host decoder → frontend | Mel: 6.99× | 1.42× |
| Frontend → Metal | Encoder: 1.38× | 1.22× |

## Scope

- Optimize the GigaAM mel frontend and host decoder.
- Remove extra attention copies.
- Add a Metal depthwise convolution kernel.
- Make transcript and token identity required benchmark checks.
- Add a Metal convolution unit test.

No public API or model format changes.

## AI Assistance

AI tools meaningfully assisted with profiling, implementation, tests, benchmarks, and documentation. I reviewed the changes, understand them, and take responsibility for them.

## Validation

The benchmark used 2 warm-up runs and 5 measured runs per process. It rotated all cumulative commits to reduce order and thermal bias.

| Check | Result |
|---|---|
| Three samples × three rounds × three transitions | 27 exact comparisons |
| Transcript text | Identical |
| Token IDs | Identical |
| Final paired rounds | 3.70×, 3.52×, 3.81× |
| Benchmark comparison tests | Passed |
| Metal depthwise convolution test | Passed |
| Release Metal build | Passed |

A wider WER and numerical test is still useful for other platforms and quantizations.