### PR TITLE
fix(ci): preserve framework symlinks when packaging the xcframework

### DIFF
--- a/scripts/ci/package_xcframework.sh
+++ b/scripts/ci/package_xcframework.sh
@@ -31,7 +31,7 @@ cp "${REPO_ROOT}/src/third_party/miniz/LICENSE" "${XCFRAMEWORK}/LICENSE.miniz"
 # Deterministic zip from the output dir (store the path as
 # "TranscribeCpp.xcframework/..." so SwiftPM unpacks it correctly).
 rm -f "$ZIP"
-( cd "$OUT_DIR" && /usr/bin/zip -qr -X "$(basename "$ZIP")" "$(basename "$XCFRAMEWORK")" )
+( cd "$OUT_DIR" && /usr/bin/zip -qry -X "$(basename "$ZIP")" "$(basename "$XCFRAMEWORK")" )
 
 echo "zip:      $ZIP"
 echo "size:     $(du -h "$ZIP" | cut -f1)"


### PR DESCRIPTION
## Summary

`package_xcframework.sh` zips with `-qr -X` but no `-y`, so the five symlinks `build_xcframework.sh` creates at lines 130-134 get dereferenced into copies. The released asset ends up with no symlinks in it.

`zipinfo` on the v0.2.0 asset: 85 entries, zero of type `l`, and the 7,849,728 byte `CTranscribe` stored three times (`Versions/A/`, `Versions/Current/`, and the framework root). Same on v0.1.2. A versioned `.framework` needs `Versions/Current` to be a real symlink, so what unpacks from the release is a layout `codesign --deep --strict` rejects.

Found this from the downstream side, via transcribe-cpp-swift in a Swift app where local builds kept failing to sign.

## Scope

packaging, `scripts/ci/package_xcframework.sh`

## AI Assistance

Yes, for the diagnosis and this one-character change. I reviewed it and understand what it does.

## Validation

Built a framework with the same five symlinks the build script creates and zipped it both ways. Current flags: 0 symlinks. With `-y`: all preserved, archive smaller, and unzipping restores `Versions/Current` as a symlink.

I have not run the full release workflow, so the SwiftPM checksum path is worth a look before this ships.
