### PR TITLE
Prevent unnecessary rebuild with Rust on Windows 

### DIFF
--- a/bindings/rust/sys/build.rs
+++ b/bindings/rust/sys/build.rs
@@ -525,6 +525,4 @@ fn stage_windows_dlls(prefix: &Path) {
             }
         }
     }
-    // Re-stage when the built DLLs change.
-    println!("cargo:rerun-if-changed={}", bin_dir.display());
 }


### PR DESCRIPTION
## Summary

For the rust bindings, removed the line to rerun if changed when staging the dlls on Windows, because it would mark as it needs a rerun when CMake writes Dlls to the bin directory during the build.rs execution.
This should reduce the building time drastically.
My tests went from 45s to 3s.

## Scope

- bindings (`bindings/rust/sys/build.rs`)

## AI Assistance

Used AI to understand what was the cause of the problem, I guided and verified the changes myself.

## Validation

The app compiles faster than before and with no issues.
Also verified that modifying the source again still triggers the rerun