### PR TITLE
whisper: opt-in adaptive encoder window for short-form audio (~3x on short clips)

### DIFF
--- a/src/arch/whisper/model.cpp
+++ b/src/arch/whisper/model.cpp
@@ -1256,13 +1256,53 @@ transcribe_status whisper_run(transcribe_session *          session,
     //        same — only short-form pads to 30s). The seek loop slices
     //        3000-frame windows and zero-pads the trailing short window.
     const int  n_mels                 = cm->hparams.enc_num_mel_bins;
-    const int  n_mel_frames_per_chunk = cm->hparams.fe_nb_max_frames > 0 ? cm->hparams.fe_nb_max_frames : 3000;
-    const int  n_samples_per_chunk    = cm->hparams.fe_n_samples > 0 ? cm->hparams.fe_n_samples : 480000;
+    int        n_mel_frames_per_chunk = cm->hparams.fe_nb_max_frames > 0 ? cm->hparams.fe_nb_max_frames : 3000;
+    int        n_samples_per_chunk    = cm->hparams.fe_n_samples > 0 ? cm->hparams.fe_n_samples : 480000;
     // Short-form = fits a single 30s window. Controls PCM padding only (HF's
     // processor pads short-form PCM to 30s before the mel, long-form does
     // not); the seek loop below is unified across both forms, matching HF's
     // generate(), which since 5.x runs one seek loop for every input length.
-    const bool is_short_form          = (n_samples <= n_samples_per_chunk);
+    bool is_short_form          = (n_samples <= n_samples_per_chunk);
+
+    // Adaptive short-form encoder window (opt-in).
+    //
+    // Whisper encodes a fixed 30 s window, so a 4 s utterance pays for 26 s of
+    // silence: measured encode cost is a flat ~275 ms at any clip length. The
+    // encoder graph is rebuilt per window (run_whisper_encoder_on_window takes
+    // n_mel_frames and reallocates on T_enc change), so the window can be sized
+    // to the audio instead.
+    //
+    // Only short-form is touched. Shrinking the window globally also re-chunks
+    // long-form, and that was measured to destroy it (long-form WER 4.31% ->
+    // 85.34% at a 20 s window) — the seek/stitch path assumes the native size.
+    //
+    // Positional embeddings were trained at 30 s, so this is a real accuracy
+    // trade; TRANSCRIBE_WINDOW_MARGIN_SECS and TRANSCRIBE_WINDOW_MIN_SECS exist
+    // so the eval harness can price it.
+    if (is_short_form && transcribe::env::flag("TRANSCRIBE_ADAPTIVE_WINDOW")) {
+        int margin = 2;
+        if (const char * mv = transcribe::env::str("TRANSCRIBE_WINDOW_MARGIN_SECS")) {
+            const int parsed = std::atoi(mv);
+            if (parsed >= 0 && parsed <= 30) { margin = parsed; }
+        }
+        int min_secs = 10;
+        if (const char * mv = transcribe::env::str("TRANSCRIBE_WINDOW_MIN_SECS")) {
+            const int parsed = std::atoi(mv);
+            if (parsed > 0 && parsed <= 30) { min_secs = parsed; }
+        }
+        const int audio_secs  = (n_samples + 16000 - 1) / 16000;
+        const int native_secs = n_samples_per_chunk / 16000;
+        int       want_secs   = audio_secs + margin;
+        if (want_secs < min_secs) { want_secs = min_secs; }
+        if (want_secs < native_secs) {
+            const int frames = want_secs * 100;   // 10 ms hop
+            if (frames % 2 == 0 && frames / 2 <= cm->hparams.enc_max_source_positions) {
+                n_mel_frames_per_chunk = frames;
+                n_samples_per_chunk    = want_secs * 16000;
+                is_short_form          = (n_samples <= n_samples_per_chunk);
+            }
+        }
+    }
 
     const int64_t t_mel_start      = ggml_time_us();
     int           total_mel_frames = 0;


### PR DESCRIPTION
## What

Whisper's encoder always processes a fixed 30 s window, so a 4 s utterance pays for 26 s of silence. Measured on M3 Max (Metal, large-v3-turbo Q8_0): encode cost is a flat ~275 ms per clip regardless of length. Since `run_whisper_encoder_on_window` already rebuilds the graph per window (it takes `n_mel_frames` and reallocates on `T_enc` change), the window can be sized to the audio instead. On 2–6 s utterances this cut end-to-end latency ~3× in our deployment (a voice assistant, where short utterances dominate).

## Why opt-in, and why short-form only

- **Short-form only.** We first tried shrinking the window globally — it re-chunks long-form and destroys it (measured: long-form Russian WER 4.31% → 85.34% at a 20 s window), because the seek/stitch path assumes the native window size. This patch touches only the `is_short_form` sizing; long-form is bit-for-bit unchanged.
- **Opt-in.** Positional embeddings were trained at 30 s, so a shorter window is a real accuracy trade. It's gated behind `TRANSCRIBE_ADAPTIVE_WINDOW`, with `TRANSCRIBE_WINDOW_MIN_SECS` (default 10) and `TRANSCRIBE_WINDOW_MARGIN_SECS` (default 2) so each deployment can price the trade. With the default 10 s floor we measured no WER regression on a 26-clip ru/en/code-switching corpus (clean + noisy).
- **Default behaviour unchanged.** Without the env var, the window stays at the model's native size for both forms.

## Validation

- Shipped in production via the Rust `transcribe-cpp-sys` bindings (patched crate) on macOS/Metal for several weeks of daily use.
- Guarded against the window ever exceeding `enc_max_source_positions`, and against odd frame counts.
- Uses the existing `transcribe::env` helpers; no new dependencies.

Happy to adjust knobs/naming or move the gate into `run_params` if you'd prefer a non-env API.