### PR TITLE
cohere: stop degenerate repetition in the greedy decoder

### DIFF
--- a/src/arch/cohere/model.cpp
+++ b/src/arch/cohere/model.cpp
@@ -634,6 +634,70 @@ transcribe_status init_context(transcribe_model *                model,
     return TRANSCRIBE_OK;
 }
 
+// Degenerate-repetition guard for the greedy decoder.
+//
+// Token selection here is a plain argmax with no repetition penalty, no
+// no-repeat-ngram and no coverage term, so there is nothing to pull the model
+// out of a self-reinforcing state: if the most likely continuation of a phrase
+// is that same phrase, it emits it until the token budget runs out. Measured on
+// real French dictation, one 21-second recording produced "Je suis allé à la
+// médiation." twelve times over — and Q8_0 and Q4_K_M did it identically, token
+// for token, which rules out quantisation and points at the search.
+//
+// The test looks at the TAIL only, so a deliberate repetition earlier in the
+// utterance survives untouched. A block must also cover at least
+// kMinLoopTokens tokens in total before it counts, which is what keeps an
+// emphatic "non non non" from being mistaken for a loop.
+namespace {
+
+constexpr int kMaxLoopBlock  = 16;   // longest repeating unit considered
+constexpr int kMinLoopRepeat = 3;    // a block must recur at least this often
+constexpr int kMinLoopTokens = 12;   // …and span at least this many tokens
+
+// Length of the repeating block at the tail, or 0 when the tail is not looping.
+int looping_tail_block(const std::vector<int32_t> & ids) {
+    const int n = static_cast<int>(ids.size());
+    for (int block = 1; block <= kMaxLoopBlock; ++block) {
+        const int repeats = std::max(kMinLoopRepeat, (kMinLoopTokens + block - 1) / block);
+        if (n < block * repeats) {
+            continue;
+        }
+        bool same = true;
+        for (int r = 1; r < repeats && same; ++r) {
+            for (int i = 0; i < block; ++i) {
+                if (ids[n - 1 - i] != ids[n - 1 - i - r * block]) {
+                    same = false;
+                    break;
+                }
+            }
+        }
+        if (same) {
+            return block;
+        }
+    }
+    return 0;
+}
+
+// Drop every copy of the repeating block but the first. What precedes the loop
+// is usually correct; only the runaway tail is discarded.
+void trim_looping_tail(std::vector<int32_t> & ids, int block) {
+    while (static_cast<int>(ids.size()) >= 2 * block) {
+        const int n = static_cast<int>(ids.size());
+        bool      same = true;
+        for (int i = 0; i < block && same; ++i) {
+            if (ids[n - 1 - i] != ids[n - 1 - i - block]) {
+                same = false;
+            }
+        }
+        if (!same) {
+            break;
+        }
+        ids.resize(static_cast<size_t>(n - block));
+    }
+}
+
+}   // namespace
+
 transcribe_status run(transcribe_session *          session,
                       const float *                 pcm,
                       int                           n_samples,
@@ -1212,6 +1276,17 @@ transcribe_status run(transcribe_session *          session,
                 if (next_token != eos_id) {
                     generated_ids.push_back(next_token);
                 }
+
+                if (const int block = looping_tail_block(generated_ids); block > 0) {
+                    trim_looping_tail(generated_ids, block);
+                    transcribe::log_msg(TRANSCRIBE_LOG_LEVEL_WARN,
+                                        "cohere run: degenerate repetition stopped at step %d "
+                                        "(block=%d tokens); the runaway tail was dropped and the "
+                                        "transcript kept up to the loop.",
+                                        step, block);
+                    next_token = eos_id;
+                    break;
+                }
             }
         } else {
             // ---------- Dynamic-graph step path (CPU) ----------
@@ -1282,6 +1357,17 @@ transcribe_status run(transcribe_session *          session,
 
                 if (next_token != eos_id) {
                     generated_ids.push_back(next_token);
+                }
+
+                if (const int block = looping_tail_block(generated_ids); block > 0) {
+                    trim_looping_tail(generated_ids, block);
+                    transcribe::log_msg(TRANSCRIBE_LOG_LEVEL_WARN,
+                                        "cohere run: degenerate repetition stopped at step %d "
+                                        "(block=%d tokens); the runaway tail was dropped and the "
+                                        "transcript kept up to the loop.",
+                                        step, block);
+                    next_token = eos_id;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
# cohere: stop degenerate repetition in the greedy decoder

## The bug

`src/arch/cohere/model.cpp` selects each token with a plain argmax over the
logits (three sites: the prompt pass at ~L1063 and both step loops). There is no
repetition penalty, no `no_repeat_ngram`, and no coverage term. The only exits
are `eos_id` and the token budget.

That leaves nothing to break a self-reinforcing state: when the most likely
continuation of a phrase is that same phrase, the decoder emits it until the
budget runs out. The result is a transcript that repeats one sentence dozens of
times, returned with `TRANSCRIBE_OK` and no diagnostic beyond the
`output truncated at N tokens` warning — which fires *because of* the loop, not
before it.

## Evidence that this is the search, not the weights

Reproduced on 60 problem recordings from a French dictation corpus, decoded
twice with the same audio and the same parameters:

| | `Q8_0` | `Q4_K_M` |
|---|---:|---:|
| files with an 8-gram repeated ≥5× | 1 | 1 |
| files where Q4 loops *more* than Q8 | — | **0** |
| files where Q4 loops *less* than Q8 | — | **0** |

On the worst case the two quantisations loop **token for token**: 6 repetitions,
43 words, identical output. Quantisation is not the cause.

A related observation: every `output truncated at 512 tokens` warning in that
corpus landed on a looping file. The cap is a symptom, not the disease.

## The fix

A tail-repetition guard in the decode loop, on both the static-graph (GPU) and
dynamic-graph (CPU) paths.

After each token is appended, `looping_tail_block()` reports the length of a
block that repeats at the end of the generated sequence. A block counts only if
it recurs at least `kMinLoopRepeat` (3) times **and** spans at least
`kMinLoopTokens` (12) tokens in total — so a 1-token block needs 12 repeats
while a 4-token block needs 3. That floor is what keeps an emphatic
`"no no no"` from being read as a loop.

When a loop is found, `trim_looping_tail()` drops every copy of the block but
the first, the decoder logs a warning, and decoding stops as if EOS had been
reached. Text preceding the loop is kept — it is usually correct; only the
runaway tail is discarded.

Only the tail is examined, so a deliberate repetition earlier in an utterance
survives untouched.

## Results

On the same 60 problem files:

| | before | after |
|---|---:|---:|
| files with an 8-gram repeated ≥5× | 1 | **0** |
| maximum repetition observed | 6 | **2** |
| files whose text changed at all | — | **4 of 60** |

56 of 60 files are byte-identical, so the guard is not rewriting healthy output.

Independently verified on a second corpus of **7,724 speech units** (28.9 h,
French meeting recordings): **36 loops stopped at the source**, and a mechanical
scan of the outputs found **no residual loop**.

## Notes

- No new dependencies; `<algorithm>` is added for `std::max`.
- The guard is unconditional. If you would rather gate it, the natural place is
  a field on `transcribe_run_params`, and I am happy to rework it that way.
- The same greedy-argmax pattern appears in the `canary` and `canary_qwen`
  decoders, which carry the same `output truncated at %d tokens` warning. I have
  not reproduced a loop there, so I have left them alone rather than change code
  I could not test.
